### PR TITLE
Alphabetize imports

### DIFF
--- a/client/source/scripts/app.js
+++ b/client/source/scripts/app.js
@@ -5,9 +5,9 @@ import Application from './components/layout/Application';
 import ApplicationContent from './components/layout/ApplicationContent';
 import Modals from './components/modals/Modals';
 import Sidebar from './components/panels/Sidebar';
-import TorrentListView from './components/panels/TorrentListView';
-import TorrentDetailsView from './components/panels/TorrentDetailsView';
 import TorrentActions from './actions/TorrentActions';
+import TorrentDetailsView from './components/panels/TorrentDetailsView';
+import TorrentListView from './components/panels/TorrentListView';
 
 class FloodApp extends React.Component {
   componentDidMount() {


### PR DESCRIPTION
What is the alphabet?

From wikipedia: `An alphabet is a standard set of letters (basic written symbols or graphemes) which is used to write one or more languages based on the general principle that the letters represent phonemes (basic significant sounds) of the spoken language.`

Why do we want `import`s to be alphabetized?

Alphabetizing `import`s  can make parsing them at a quick glance of the eyes easier.