### PR TITLE
Remove conditional filter counts

### DIFF
--- a/client/scripts/components/Sidebar/StatusFilters.js
+++ b/client/scripts/components/Sidebar/StatusFilters.js
@@ -19,7 +19,6 @@ const METHODS_TO_BIND = [
   'handleClick',
   'onStatusFilterChange',
   'onTorrentStatusCountChange',
-  'onTrackerFilterChange',
   'updateStatusCount'
 ];
 
@@ -42,14 +41,13 @@ export default class StatusFilters extends React.Component {
     TorrentStore.listen(EventTypes.CLIENT_TORRENTS_REQUEST_SUCCESS, this.onTorrentRequestSuccess);
     TorrentFilterStore.listen(EventTypes.CLIENT_TORRENT_STATUS_COUNT_CHANGE, this.onTorrentStatusCountChange);
     TorrentFilterStore.listen(EventTypes.UI_TORRENTS_FILTER_STATUS_CHANGE, this.onStatusFilterChange);
-    TorrentFilterStore.listen(EventTypes.UI_TORRENTS_FILTER_TRACKER_CHANGE, this.onTrackerFilterChange);
     TorrentFilterStore.fetchTorrentStatusCount();
   }
 
   componentWillUnmount() {
+    TorrentStore.unlisten(EventTypes.CLIENT_TORRENTS_REQUEST_SUCCESS, this.onTorrentRequestSuccess);
     TorrentFilterStore.unlisten(EventTypes.CLIENT_TORRENT_STATUS_COUNT_CHANGE, this.onTorrentStatusCountChange);
     TorrentFilterStore.unlisten(EventTypes.UI_TORRENTS_FILTER_STATUS_CHANGE, this.onStatusFilterChange);
-    TorrentFilterStore.unlisten(EventTypes.UI_TORRENTS_FILTER_TRACKER_CHANGE, this.onTrackerFilterChange);
   }
 
   handleClick(filter) {
@@ -67,10 +65,6 @@ export default class StatusFilters extends React.Component {
   }
 
   onTorrentStatusCountChange() {
-    this.updateStatusCount();
-  }
-
-  onTrackerFilterChange() {
     this.updateStatusCount();
   }
 
@@ -125,30 +119,6 @@ export default class StatusFilters extends React.Component {
 
   updateStatusCount() {
     let statusCount = TorrentFilterStore.getTorrentStatusCount();
-    let trackerFilter = TorrentFilterStore.getTrackerFilter();
-
-    if (TorrentFilterStore.getTrackerFilter() !== 'all') {
-      let totalStatusCount = 0;
-      let torrents = TorrentStore.getAllTorrents();
-
-      Object.keys(statusCount).forEach((key) => {
-        statusCount[key] = 0;
-      });
-
-      Object.keys(torrents).forEach((hash) => {
-        let torrent = torrents[hash];
-
-        if (torrent.trackers.indexOf(trackerFilter) > -1) {
-          totalStatusCount++;
-          torrent.status.forEach((status) => {
-            statusCount[propsMap.serverStatus[status]]++;
-          });
-        }
-      });
-
-      statusCount.all = totalStatusCount;
-    }
-
     this.setState({statusCount});
   }
 

--- a/client/scripts/components/Sidebar/TrackerFilters.js
+++ b/client/scripts/components/Sidebar/TrackerFilters.js
@@ -11,7 +11,6 @@ import UIActions from '../../actions/UIActions';
 const METHODS_TO_BIND = [
   'getFilters',
   'handleClick',
-  'onStatusFilterChange',
   'onTrackerFilterChange',
   'onTorrentTrackerCountChange',
   'updateTrackerCount'
@@ -32,25 +31,26 @@ export default class TrackerFilters extends React.Component {
   }
 
   componentDidMount() {
-    TorrentStore.listen(EventTypes.CLIENT_TORRENTS_REQUEST_SUCCESS, this.onTorrentRequestSuccess);
-    TorrentFilterStore.listen(EventTypes.CLIENT_TORRENT_TRACKER_COUNT_CHANGE, this.onTorrentTrackerCountChange);
-    TorrentFilterStore.listen(EventTypes.UI_TORRENTS_FILTER_TRACKER_CHANGE, this.onTrackerFilterChange);
-    TorrentFilterStore.listen(EventTypes.UI_TORRENTS_FILTER_STATUS_CHANGE, this.onStatusFilterChange);
+    TorrentStore.listen(EventTypes.CLIENT_TORRENTS_REQUEST_SUCCESS,
+      this.onTorrentRequestSuccess);
+    TorrentFilterStore.listen(EventTypes.CLIENT_TORRENT_TRACKER_COUNT_CHANGE,
+      this.onTorrentTrackerCountChange);
+    TorrentFilterStore.listen(EventTypes.UI_TORRENTS_FILTER_TRACKER_CHANGE,
+      this.onTrackerFilterChange);
   }
 
   componentWillUnmount() {
-    TorrentFilterStore.unlisten(EventTypes.CLIENT_TORRENT_TRACKER_COUNT_CHANGE, this.onTorrentTrackerCountChange);
-    TorrentFilterStore.unlisten(EventTypes.UI_TORRENTS_FILTER_TRACKER_CHANGE, this.onTrackerFilterChange);
-    TorrentFilterStore.unlisten(EventTypes.UI_TORRENTS_FILTER_STATUS_CHANGE, this.onStatusFilterChange);
+    TorrentStore.unlisten(EventTypes.CLIENT_TORRENTS_REQUEST_SUCCESS,
+      this.onTorrentRequestSuccess);
+    TorrentFilterStore.unlisten(EventTypes.CLIENT_TORRENT_TRACKER_COUNT_CHANGE,
+      this.onTorrentTrackerCountChange);
+    TorrentFilterStore.unlisten(EventTypes.UI_TORRENTS_FILTER_TRACKER_CHANGE,
+      this.onTrackerFilterChange);
     TorrentFilterStore.fetchTorrentTrackerCount();
   }
 
   handleClick(filter) {
     UIActions.setTorrentTrackerFilter(filter);
-  }
-
-  onStatusFilterChange() {
-    this.updateTrackerCount();
   }
 
   onTrackerFilterChange() {
@@ -84,30 +84,6 @@ export default class TrackerFilters extends React.Component {
 
   updateTrackerCount() {
     let trackerCount = TorrentFilterStore.getTorrentTrackerCount();
-    let statusFilter = TorrentFilterStore.getStatusFilter();
-
-    if (statusFilter !== 'all') {
-      let torrentCount = 0;
-      let torrents = TorrentStore.getAllTorrents();
-
-      Object.keys(trackerCount).forEach((key) => {
-        trackerCount[key] = 0;
-      });
-
-      Object.keys(torrents).forEach((hash) => {
-        let torrent = torrents[hash];
-
-        if (torrent.status.indexOf(propsMap.clientStatus[statusFilter]) > -1) {
-          torrentCount++;
-          torrent.trackers.forEach((tracker) => {
-            trackerCount[tracker]++;
-          });
-        }
-      });
-
-      trackerCount.all = torrentCount;
-    }
-
     this.setState({trackerCount});
   }
 


### PR DESCRIPTION
This will get increasingly more expensive as more filtering is introduced, so removing it for now. Perhaps a more performant implementation can be introduced in the future.