### PR TITLE
Serve static assets locally

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -97,7 +97,8 @@ gulp.task('browsersync', () => {
     online: true,
     open: false,
     port: 4200,
-    proxy: proxyPath
+    proxy: proxyPath,
+    serveStatic: ['.', './server/assets']
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "xmlrpc": "^1.3.0"
   },
   "devDependencies": {
-    "browser-sync": "^2.10.0",
+    "browser-sync": "^2.13.0",
     "envify": "^3.4.0",
     "eslint": "^2.8.0",
     "eslint-config-airbnb": "^9.0.1",


### PR DESCRIPTION
When running Browser Sync server, always serve static assets locally.