### PR TITLE
Add support for long TLDs

### DIFF
--- a/shared/util/regEx.js
+++ b/shared/util/regEx.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const regEx = {
-  domainName: /https?:\/\/(?:www\.)?([-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b)*(\/[\/\d\w\.-]*)*(?:[\?])*(.+)*/gi
+  domainName: /https?:\/\/(?:www\.)?([-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,18}\b)*(\/[\/\d\w\.-]*)*(?:[\?])*(.+)*/gi
 };
 
 module.exports = regEx;


### PR DESCRIPTION
Some trackers use top-level domains with more than 6 characters.

At the moment, the longest non-IDN TLD is 18-characters long ([according to IANA](http://data.iana.org/TLD/tlds-alpha-by-domain.txt)).