### PR TITLE
Fix torrents with more than one tracker

### DIFF
--- a/shared/util/regEx.js
+++ b/shared/util/regEx.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const regEx = {
-  domainName: /https?:\/\/(?:www\.)?([-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,18}\b)*(\/[\/\d\w\.-]*)*(?:[\?])*(.+)*/gi
+  domainName: /https?:\/\/(?:www\.)?([-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,18}\b)*(\/[\/\d\w\.-]*)*(?:[\?])*(.+)*/i
 };
 
 module.exports = regEx;


### PR DESCRIPTION
Only the first tracker was usable in the sidebar filter.

'getCalculatedTrackers' method returned only the first domain.

Global regEx matching should not be used on a shared regEx instance. Look [here](http://stackoverflow.com/a/2142007).