### PR TITLE
Rely on mkdirp Node module instead of mkdir command

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "jsonwebtoken": "^7.0.1",
     "jsx-loader": "^0.13.2",
     "lodash": "^4.3.0",
+    "mkdirp": "^0.5.1",
     "moment": "^2.14.1",
     "morgan": "^1.5.3",
     "multer": "^1.1.0",

--- a/server/models/ClientRequest.js
+++ b/server/models/ClientRequest.js
@@ -1,5 +1,6 @@
 'use strict';
 
+let mkdirp = require('mkdirp');
 let mv = require('mv');
 let path = require('path');
 let util = require('util');
@@ -178,9 +179,11 @@ class ClientRequest {
 
   createDirectoryMethodCall(options) {
     if (options.path) {
-      this.requests.push(
-        this.getMethodCall('execute2', ['mkdir', '-p', options.path])
-      );
+      mkdirp(options.path, (error) => {
+        if (error) {
+          console.trace('Error creating directory.', error);
+        }
+      });
     }
   }
 


### PR DESCRIPTION
This PR removes the passing of the `mkdir` command to rTorrent and instead uses [mkdirp](https://github.com/substack/node-mkdirp) which should be more reliable.