### PR TITLE
Improve unknown dates handling

### DIFF
--- a/client/scripts/components/Modals/TorrentDetailsModal/TorrentGeneralInfo.js
+++ b/client/scripts/components/Modals/TorrentDetailsModal/TorrentGeneralInfo.js
@@ -16,8 +16,16 @@ class TorrentGeneralInfo extends React.Component {
   render() {
     let torrent = this.props.torrent;
 
-    let added = new Date(torrent.added * 1000);
-    let creation = new Date(torrent.creationDate * 1000);
+    let added = null;
+    if (torrent.added) {
+      added = new Date(torrent.added * 1000);
+    }
+
+    let creation = null;
+    if (torrent.creationDate) {
+      creation = new Date(torrent.creationDate * 1000);
+    }
+
     let totalSize = format.data(torrent.sizeBytes);
     let freeDiskSpace = format.data(torrent.freeDiskSpace);
 
@@ -49,13 +57,13 @@ class TorrentGeneralInfo extends React.Component {
                 />
               </td>
               <td className="torrent-details__detail__value">
-                <FormattedDate
-                  value={added}
-                  year="numeric"
-                  month="long"
-                  day="2-digit"
-                /> <FormattedTime
-                  value={added} />
+                {added
+                  ? this.props.intl.formatDate(added, {
+                    year: 'numeric',
+                    month: 'long',
+                    day: '2-digit'}) + ' ' +
+                    this.props.intl.formatTime(added)
+                  : valueNotAvailable}
               </td>
             </tr>
             <tr className="torrent-details__detail torrent-details__detail--free-disk-space">
@@ -188,14 +196,13 @@ class TorrentGeneralInfo extends React.Component {
                 />
               </td>
               <td className="torrent-details__detail__value">
-                <FormattedDate
-                  value={creation}
-                  year="numeric"
-                  month="long"
-                  day="2-digit"
-                /> <FormattedTime
-                  value={creation}
-                />
+                {creation
+                  ? this.props.intl.formatDate(creation, {
+                    year: 'numeric',
+                    month: 'long',
+                    day: '2-digit'}) + ' ' +
+                    this.props.intl.formatTime(creation)
+                  : valueNotAvailable}
               </td>
             </tr>
             <tr className="torrent-details__detail torrent-details__detail--hash">

--- a/client/scripts/components/TorrentList/Torrent.js
+++ b/client/scripts/components/TorrentList/Torrent.js
@@ -105,9 +105,12 @@ export default class Torrent extends React.Component {
   render() {
     let torrent = this.props.torrent;
 
-    let added = new Date(torrent.added * 1000);
-    let addedString = (added.getMonth() + 1) + '/' + added.getDate() + '/' +
-      added.getFullYear();
+    let addedString = '\u2014'; // em dash
+    if (torrent.added) {
+      let added = new Date(torrent.added * 1000);
+      addedString = (added.getMonth() + 1) + '/' + added.getDate() + '/' +
+        added.getFullYear();
+    }
     let completed = format.data(torrent.bytesDone);
     let downloadRate = format.data(torrent.downloadRate, '/s');
     let downloadTotal = format.data(torrent.downloadTotal);

--- a/client/scripts/components/TorrentList/Torrent.js
+++ b/client/scripts/components/TorrentList/Torrent.js
@@ -21,6 +21,7 @@ const ICONS = {
   disk: <DiskIcon />,
   downloadThick: <DownloadThickIcon />,
   information: <InformationIcon />,
+  calendar: <CalendarIcon />,
   peers: <PeersIcon />,
   ratio: <RatioIcon />,
   seeds: <SeedsIcon />,

--- a/client/scripts/components/TorrentList/Torrent.js
+++ b/client/scripts/components/TorrentList/Torrent.js
@@ -106,12 +106,6 @@ export default class Torrent extends React.Component {
   render() {
     let torrent = this.props.torrent;
 
-    let addedString = '\u2014'; // em dash
-    if (torrent.added) {
-      let added = new Date(torrent.added * 1000);
-      addedString = (added.getMonth() + 1) + '/' + added.getDate() + '/' +
-        added.getFullYear();
-    }
     let completed = format.data(torrent.bytesDone);
     let downloadRate = format.data(torrent.downloadRate, '/s');
     let downloadTotal = format.data(torrent.downloadTotal);
@@ -151,6 +145,51 @@ export default class Torrent extends React.Component {
       );
     }
 
+    let tertiaryDetails = [
+      <li className="torrent__details--completed">
+        <span className="torrent__details__icon">{ICONS.downloadThick}</span>
+        {torrent.percentComplete}
+        <em className="unit">%</em>
+        &nbsp;&mdash;&nbsp;
+        {completed.value}
+        <em className="unit">{completed.unit}</em>
+      </li>,
+      <li className="torrent__details--uploaded">
+        <span className="torrent__details__icon">{ICONS.uploadThick}</span>
+        {uploadTotal.value}
+        <em className="unit">{uploadTotal.unit}</em>
+      </li>,
+      <li className="torrent__details--ratio">
+        <span className="torrent__details__icon">{ICONS.ratio}</span>
+        {ratio}
+      </li>,
+      <li className="torrent__details--size">
+        <span className="torrent__details__icon">{ICONS.disk}</span>
+        {totalSize.value}
+        <em className="unit">{totalSize.unit}</em>
+      </li>,
+      <li className="torrent__details--peers">
+        <span className="torrent__details__icon">{ICONS.peers}</span>
+        {torrent.connectedPeers} <em className="unit">of</em> {torrent.totalPeers}
+      </li>,
+      <li className="torrent__details--seeds">
+        <span className="torrent__details__icon">{ICONS.seeds}</span>
+        {torrent.connectedSeeds} <em className="unit">of</em> {torrent.totalSeeds}
+      </li>
+    ];
+
+    if (torrent.added) {
+      let added = new Date(torrent.added * 1000);
+      let addedString = (added.getMonth() + 1) + '/' + added.getDate() + '/' + added.getFullYear();
+
+      tertiaryDetails.push(
+        <li className="torrent__details--added">
+          <span className="torrent__details__icon">{ICONS.calendar}</span>
+          {addedString}
+        </li>
+      )
+    }
+
     return (
       <li className={torrentClasses} onClick={this.handleClick}
         onContextMenu={this.handleRightClick}>
@@ -162,40 +201,7 @@ export default class Torrent extends React.Component {
         </ul>
         <div className="torrent__details torrent__details--tertiary">
           <ul className="torrent__details torrent__details--tertiary--stats">
-            <li className="torrent__details--completed">
-              <span className="torrent__details__icon">{ICONS.downloadThick}</span>
-              {torrent.percentComplete}
-              <em className="unit">%</em>
-              &nbsp;&mdash;&nbsp;
-              {completed.value}
-              <em className="unit">{completed.unit}</em>
-            </li>
-            <li className="torrent__details--uploaded">
-              <span className="torrent__details__icon">{ICONS.uploadThick}</span>
-              {uploadTotal.value}
-              <em className="unit">{uploadTotal.unit}</em>
-            </li>
-            <li className="torrent__details--ratio">
-              <span className="torrent__details__icon">{ICONS.ratio}</span>
-              {ratio}
-            </li>
-            <li className="torrent__details--size">
-              <span className="torrent__details__icon">{ICONS.disk}</span>
-              {totalSize.value}
-              <em className="unit">{totalSize.unit}</em>
-            </li>
-            <li className="torrent__details--added">
-              <span className="torrent__details__icon">{ICONS.calendar}</span>
-              {addedString}
-            </li>
-            <li className="torrent__details--peers">
-              <span className="torrent__details__icon">{ICONS.peers}</span>
-              {torrent.connectedPeers} <em className="unit">of</em> {torrent.totalPeers}
-            </li>
-            <li className="torrent__details--seeds">
-              <span className="torrent__details__icon">{ICONS.seeds}</span>
-              {torrent.connectedSeeds} <em className="unit">of</em> {torrent.totalSeeds}
-            </li>
+            {tertiaryDetails}
           </ul>
           <ul className="torrent__details torrent__details--tertiary--tags torrent__tags tag">
             {this.getTags(torrent.tags)}

--- a/client/scripts/components/TorrentList/Torrent.js
+++ b/client/scripts/components/TorrentList/Torrent.js
@@ -187,7 +187,7 @@ export default class Torrent extends React.Component {
           <span className="torrent__details__icon">{ICONS.calendar}</span>
           {addedString}
         </li>
-      )
+      );
     }
 
     return (

--- a/client/scripts/components/TorrentList/Torrent.js
+++ b/client/scripts/components/TorrentList/Torrent.js
@@ -146,7 +146,7 @@ export default class Torrent extends React.Component {
     }
 
     let tertiaryDetails = [
-      <li className="torrent__details--completed">
+      <li className="torrent__details--completed" key="downloaded">
         <span className="torrent__details__icon">{ICONS.downloadThick}</span>
         {torrent.percentComplete}
         <em className="unit">%</em>
@@ -154,25 +154,25 @@ export default class Torrent extends React.Component {
         {completed.value}
         <em className="unit">{completed.unit}</em>
       </li>,
-      <li className="torrent__details--uploaded">
+      <li className="torrent__details--uploaded" key="uploaded">
         <span className="torrent__details__icon">{ICONS.uploadThick}</span>
         {uploadTotal.value}
         <em className="unit">{uploadTotal.unit}</em>
       </li>,
-      <li className="torrent__details--ratio">
+      <li className="torrent__details--ratio" key="ratio">
         <span className="torrent__details__icon">{ICONS.ratio}</span>
         {ratio}
       </li>,
-      <li className="torrent__details--size">
+      <li className="torrent__details--size" key="size">
         <span className="torrent__details__icon">{ICONS.disk}</span>
         {totalSize.value}
         <em className="unit">{totalSize.unit}</em>
       </li>,
-      <li className="torrent__details--peers">
+      <li className="torrent__details--peers" key="peers">
         <span className="torrent__details__icon">{ICONS.peers}</span>
         {torrent.connectedPeers} <em className="unit">of</em> {torrent.totalPeers}
       </li>,
-      <li className="torrent__details--seeds">
+      <li className="torrent__details--seeds" key="seeds">
         <span className="torrent__details__icon">{ICONS.seeds}</span>
         {torrent.connectedSeeds} <em className="unit">of</em> {torrent.totalSeeds}
       </li>
@@ -183,7 +183,7 @@ export default class Torrent extends React.Component {
       let addedString = (added.getMonth() + 1) + '/' + added.getDate() + '/' + added.getFullYear();
 
       tertiaryDetails.push(
-        <li className="torrent__details--added">
+        <li className="torrent__details--added" key="added">
           <span className="torrent__details__icon">{ICONS.calendar}</span>
           {addedString}
         </li>

--- a/server/models/Torrent.js
+++ b/server/models/Torrent.js
@@ -257,15 +257,25 @@ class Torrent {
   }
 
   getCalculatedAdded(clientData) {
-    return clientData.added.trim();
+    return this.cleanUpDate(clientData.added);
   }
 
   getCalculatedCreationDate(clientData) {
-    if (clientData.creationDate === '0') {
+    return this.cleanUpDate(clientData.creationDate);
+  }
+
+  cleanUpDate(dirtyDate) {
+    if (!dirtyDate) {
       return '';
     }
 
-    return clientData.creationDate;
+    let date = dirtyDate.trim();
+
+    if (date === '0') {
+      return '';
+    }
+
+    return date;
   }
 
   updateData(clientData, opts) {

--- a/server/models/Torrent.js
+++ b/server/models/Torrent.js
@@ -256,6 +256,18 @@ class Torrent {
     return trackerDomains;
   }
 
+  getCalculatedAdded(clientData) {
+    return clientData.added.trim();
+  }
+
+  getCalculatedCreationDate(clientData) {
+    if (clientData.creationDate === '0') {
+      return '';
+    }
+
+    return clientData.creationDate;
+  }
+
   updateData(clientData, opts) {
     // TODO somehow communicate that only some props were updated
     this._lastUpdated = opts.currentTime || Date.now();


### PR DESCRIPTION
For some torrents, _rtorrent_ returns zero or an empty string in the `added` and/or `creationDate` properties. So it's displayed as '1/1/1970' in the UI.

![capture d ecran 2016-08-14 a 00 09 24](https://cloud.githubusercontent.com/assets/90145/17648552/20ac44e4-621a-11e6-8866-c6a155c22178.png)

![capture d ecran 2016-08-14 a 00 11 32](https://cloud.githubusercontent.com/assets/90145/17648553/25d69208-621a-11e6-9bfb-dd33979f1077.png)

I made a change to instead display a dash in the torrent list and _None_ in the detailed view.

![capture d ecran 2016-08-14 a 00 18 05](https://cloud.githubusercontent.com/assets/90145/17648566/7f815784-621a-11e6-8fcc-662f68d092c2.png)

![capture d ecran 2016-08-14 a 00 20 40](https://cloud.githubusercontent.com/assets/90145/17648567/860e9b5c-621a-11e6-857a-9108a554045e.png)

I don't have much inspiration, do you think it's good enough as UX? If you think of something better, I'd be happy to improve this.

EDIT: I also fixed the missing calendar icon in the torrent list.

![capture d ecran 2016-08-14 a 13 07 55](https://cloud.githubusercontent.com/assets/90145/17648728/5e4c3e70-6220-11e6-8cf8-69c933423c5d.png)