### PR TITLE
Add SSL Support

### DIFF
--- a/config.template.js
+++ b/config.template.js
@@ -10,10 +10,10 @@ const CONFIG = {
     port: 5000,
     socket: false,
     socketPath: '/tmp/rtorrent.sock'
-  }
+  },
   ssl: false,
-  sslKey: '/etc/letsencrypt/live/my.awesome.domain.com/fullchain.pem',
-  sslCert: '/etc/letsencrypt/live/my.awesome.domain.com/privkey.pem'
+  sslKey: '/absolute/path/to/key/',
+  sslCert: '/absolute/path/to/certificate/'
 };
 
 module.exports = CONFIG;

--- a/config.template.js
+++ b/config.template.js
@@ -11,6 +11,9 @@ const CONFIG = {
     socket: false,
     socketPath: '/tmp/rtorrent.sock'
   }
+  ssl: false,
+  sslKey: '/etc/letsencrypt/live/my.awesome.domain.com/fullchain.pem',
+  sslCert: '/etc/letsencrypt/live/my.awesome.domain.com/privkey.pem'
 };
 
 module.exports = CONFIG;

--- a/server/bin/www
+++ b/server/bin/www
@@ -2,9 +2,9 @@
 
 'use strict';
 
+let fs = require('fs');
 // Ensure we have a user-defined config.js for use throughout the app.
 try {
-  let fs = require('fs');
   fs.accessSync('./config.js', fs.F_OK);
 } catch (e) {
   console.error('Cannot start Flood server, config.js is missing. Copy ' +
@@ -15,7 +15,6 @@ try {
 var app = require('../app');
 let config = require('../../config');
 var debug = require('debug')('flood:server');
-var http = require('http');
 
 /**
  * Get port from environment and store in Express.
@@ -25,10 +24,27 @@ var port = normalizePort(config.floodServerPort);
 app.set('port', port);
 
 /**
- * Create HTTP server.
+ * Create HTTP or HTTPS server.
  */
+ 
+var ssl = Boolean(config.ssl);
+var server;
 
-var server = http.createServer(app);
+if (ssl) {
+	if (!config.sslKey || ! config.sslCert){
+		console.error('Cannot start Flood server in secure mode, `sslKey` or `sslCert` is missing in config.js.');
+		return;
+	}
+	
+	var options = {
+		key: fs.readFileSync(config.sslKey),
+		cert: fs.readFileSync(config.sslCert)
+	};
+	server = require('https').createServer(options, app);
+	
+} else {
+	server = require('http').createServer(app);
+}
 
 /**
  * Listen on provided port, on all network interfaces.

--- a/server/bin/www
+++ b/server/bin/www
@@ -27,23 +27,22 @@ app.set('port', port);
  * Create HTTP or HTTPS server.
  */
  
-var ssl = Boolean(config.ssl);
-var server;
+let server;
 
-if (ssl) {
-	if (!config.sslKey || ! config.sslCert){
-		console.error('Cannot start Flood server in secure mode, `sslKey` or `sslCert` is missing in config.js.');
-		return;
-	}
-	
-	var options = {
-		key: fs.readFileSync(config.sslKey),
-		cert: fs.readFileSync(config.sslCert)
-	};
-	server = require('https').createServer(options, app);
-	
+if (config.ssl) {
+  if (!config.sslKey || ! config.sslCert){
+    console.error('Cannot start Flood server in secure mode, `sslKey` or `sslCert` is missing in config.js.');
+    return;
+  }
+  
+  var options = {
+    key: fs.readFileSync(config.sslKey),
+    cert: fs.readFileSync(config.sslCert)
+  };
+  server = require('https').createServer(options, app);
+  
 } else {
-	server = require('http').createServer(app);
+  server = require('http').createServer(app);
 }
 
 /**


### PR DESCRIPTION
I just added SSL Support to flood ;)

Also I give you my apache configuration for those who want to make a proxy w/ SSL :)

    <VirtualHost *:80>
    	ServerName flood.my.awesome.domain.com
    	Redirect "/" "https://flood.my.awesome.domain.com"
    </VirtualHost>
    
    <VirtualHost *:443>
    	ServerName flood.my.awesome.domain.com
    	
    	SSLEngine on
    	SSLProxyEngine on
    	SSLProxyVerify none 
    	SSLProxyCheckPeerCN off
    	SSLProxyCheckPeerName off
    	SSLProxyCheckPeerExpire off
    	SSLCertificateFile /etc/letsencrypt/live/flood.my.awesome.domain.com/cert.pem
    	SSLCertificateChainFile /etc/letsencrypt/live/flood.my.awesome.domain.com/chain.pem
    	SSLCertificateKeyFile /etc/letsencrypt/live/flood.my.awesome.domain.com/privkey.pem
		
    	ProxyPass / https://localhost:8001/
    	ProxyPassReverse / https://localhost:8001/
    </VirtualHost>