### PR TITLE
Fix torrent list styling bugs

### DIFF
--- a/client/sass/components/_progress-bar.scss
+++ b/client/sass/components/_progress-bar.scss
@@ -18,6 +18,7 @@ $progress-bar--fill: $green;
 $progress-bar--fill--checking: #8899a8;
 $progress-bar--fill--completed: $blue;
 $progress-bar--fill--error: #e95779;
+$progress-bar--fill--error--stopped: #f2acbc;
 $progress-bar--fill--selected: #fff;
 $progress-bar--fill--stopped: #e3e5e5;
 
@@ -63,6 +64,10 @@ $progress-bar--fill--stopped: #e3e5e5;
       .is-selected & {
         fill: $progress-bar--fill--selected;
       }
+
+      .has-error.is-stopped & {
+        fill: $progress-bar--fill--error--stopped;
+      }
     }
   }
 
@@ -97,6 +102,10 @@ $progress-bar--fill--stopped: #e3e5e5;
       background: $progress-bar--fill--selected;
     }
 
+    .has-error.is-stopped & {
+      background: $progress-bar--fill--error--stopped;
+    }
+
     &__wrapper {
       flex: 1 1 auto;
       position: relative;
@@ -126,6 +135,10 @@ $progress-bar--fill--stopped: #e3e5e5;
           background: $progress-bar--background--selected;
         }
 
+        .has-error.is-stopped & {
+          background: $progress-bar--fill--error--stopped;
+        }
+
         .is-selected.is-stopped & {
           background: $progress-bar--background--selected--stopped;
           opacity: 1;
@@ -141,6 +154,7 @@ $progress-bar--fill--stopped: #e3e5e5;
             rgba($progress-bar--fill--checking, 0.5) 100%);
           background-size: 4px 4px;
           height: $progress-bar--height;
+          top: 0;
         }
 
         .is-selected.is-checking & {

--- a/client/sass/components/_torrents.scss
+++ b/client/sass/components/_torrents.scss
@@ -4,6 +4,7 @@ $torrent-list--offset: 10px;
 
 $torrent--primary--foreground: #5b6d7c;
 $torrent--primary--foreground--error: #e95779;
+$torrent--primary--foreground--error--stopped: rgba($torrent--primary--foreground--error, 0.6);
 $torrent--primary--foreground--stopped: rgba(#333332, 0.5);
 $torrent--primary--foreground--selected: #fff;
 $torrent--primary--foreground--selected--stopped: rgba($torrent--primary--foreground--selected, 0.6);
@@ -223,6 +224,10 @@ $more-info--border: $textbox-repeater--button--border;
 
       .is-selected & {
         color: $torrent--primary--foreground--selected;
+      }
+
+      .has-error.is-stopped & {
+        color: $torrent--primary--foreground--error--stopped;
       }
 
       .is-selected.is-stopped & {


### PR DESCRIPTION
This PR fixes two issues with the torrent list styles:
* The hash checking animation was misaligned by one pixel
* Stopped & errored torrents didn't have the same transparent look that their non-errored counterparts did