### PR TITLE
Move dependency registration to components' constructor

### DIFF
--- a/client/scripts/app.js
+++ b/client/scripts/app.js
@@ -37,9 +37,7 @@ class FloodApp extends React.Component {
     METHODS_TO_BIND.forEach((method) => {
       this[method] = this[method].bind(this);
     });
-  }
 
-  componentWillMount() {
     UIStore.registerDependency({
       id: 'flood-settings',
       message: (

--- a/client/scripts/components/Panels/Sidebar.js
+++ b/client/scripts/components/Panels/Sidebar.js
@@ -18,7 +18,9 @@ import TrackerFilters from '../Sidebar/TrackerFilters';
 import UIStore from '../../stores/UIStore';
 
 class Sidebar extends React.Component {
-  componentDidMount() {
+  constructor() {
+    super();
+
     UIStore.registerDependency({
       id: 'torrent-taxonomy',
       message: (
@@ -26,6 +28,9 @@ class Sidebar extends React.Component {
           defaultMessage="Torrent Taxonomy" />
       ),
     });
+  }
+
+  componentDidMount() {
     TorrentStore.listen(EventTypes.CLIENT_TORRENTS_REQUEST_SUCCESS,
       this.onTorrentRequestSuccess);
     TorrentFilterStore.listen(EventTypes.CLIENT_FETCH_TORRENT_TAXONOMY_SUCCESS,

--- a/client/scripts/components/Sidebar/NotificationsButton.js
+++ b/client/scripts/components/Sidebar/NotificationsButton.js
@@ -83,9 +83,7 @@ class NotificationsButton extends React.Component {
     METHODS_TO_BIND.forEach((method) => {
       this[method] = this[method].bind(this);
     });
-  }
 
-  componentWillMount() {
     UIStore.registerDependency({
       id: 'notifications',
       message: (

--- a/client/scripts/components/Sidebar/TransferData.js
+++ b/client/scripts/components/Sidebar/TransferData.js
@@ -33,9 +33,7 @@ class TransferData extends React.Component {
     METHODS_TO_BIND.forEach((method) => {
       this[method] = this[method].bind(this);
     });
-  }
 
-  componentDidMount() {
     UIStore.registerDependency([
       {
         id: 'transfer-data',
@@ -52,6 +50,9 @@ class TransferData extends React.Component {
         )
       }
     ]);
+  }
+
+  componentDidMount() {
     this.setState({
       sidebarWidth: ReactDOM.findDOMNode(this).offsetWidth
     });

--- a/client/scripts/components/TorrentList/index.js
+++ b/client/scripts/components/TorrentList/index.js
@@ -47,7 +47,7 @@ const METHODS_TO_BIND = [
 let cachedTorrentList = null;
 
 class TorrentListContainer extends React.Component {
-  constructor() {
+  constructor(props) {
     super();
 
     this.lastScrollPosition = 0;
@@ -76,13 +76,14 @@ class TorrentListContainer extends React.Component {
     this.setScrollPosition = _.throttle(this.setScrollPosition, 250, {
       trailing: true
     });
+
+    UIStore.registerDependency({
+      id: 'torrent-list',
+      message: props.intl.formatMessage(MESSAGES.torrentListDependency)
+    });
   }
 
   componentDidMount() {
-    UIStore.registerDependency({
-      id: 'torrent-list',
-      message: this.props.intl.formatMessage(MESSAGES.torrentListDependency)
-    });
     TorrentStore.listen(EventTypes.UI_TORRENT_SELECTION_CHANGE, this.onTorrentSelectionChange);
     TorrentStore.listen(EventTypes.CLIENT_TORRENTS_REQUEST_SUCCESS, this.onReceiveTorrentsSuccess);
     TorrentStore.listen(EventTypes.UI_TORRENTS_LIST_FILTERED, this.onReceiveTorrentsSuccess);


### PR DESCRIPTION
This PR moves all `UIStore.registerDependency` calls to the constructor rather than the React lifecycle methods. This should fix https://github.com/jfurrow/flood/issues/176