### PR TITLE
Remove node_modules reference in npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "scripts": {
     "preinstall": "npm prune",
-    "prestart": "./node_modules/.bin/gulp dist",
-    "start": "./node_modules/.bin/nodemon ./server/bin/www",
+    "prestart": "gulp dist",
+    "start": "nodemon ./server/bin/www",
     "start:production": "npm run prestart; node ./server/bin/www",
-    "start:watch": "NODE_ENV='development' ./node_modules/.bin/gulp livereload"
+    "start:watch": "NODE_ENV='development' gulp livereload"
   },
   "dependencies": {
     "axios": "^0.12.0",


### PR DESCRIPTION
It turns out the direct path to these binaries aren't necessary. https://github.com/npm/npm/issues/4040