### PR TITLE
Fix mediainfo for single-file torrents

### DIFF
--- a/server/util/mediainfo.js
+++ b/server/util/mediainfo.js
@@ -21,7 +21,7 @@ module.exports = {
 
       try {
         child_process.execFile(
-          'mediainfo', [details.directory], function(error, stdout, stderr) {
+          'mediainfo', [details.basePath], function(error, stdout, stderr) {
             if (error) {
               callback(null, {error});
               return;


### PR DESCRIPTION
When asked for single-file torrents, mediainfo is run on the **whole** data directory, causing error on stdout buffer.

This fixes #187.