### PR TITLE
Stop catching all erros in promises

### DIFF
--- a/client/scripts/actions/AuthActions.js
+++ b/client/scripts/actions/AuthActions.js
@@ -14,8 +14,7 @@ let AuthActions = {
           type: ActionTypes.AUTH_LOGIN_SUCCESS,
           data
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.AUTH_LOGIN_ERROR,
           error: error.data.message
@@ -33,8 +32,7 @@ let AuthActions = {
           type: ActionTypes.AUTH_CREATE_USER_SUCCESS,
           data
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.AUTH_CREATE_USER_ERROR,
           error
@@ -55,8 +53,7 @@ let AuthActions = {
             ...data
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.AUTH_DELETE_USER_ERROR,
           error: {
@@ -77,8 +74,7 @@ let AuthActions = {
           type: ActionTypes.AUTH_LIST_USERS_SUCCESS,
           data
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.AUTH_LIST_USERS_ERROR,
           error
@@ -96,8 +92,7 @@ let AuthActions = {
           type: ActionTypes.AUTH_REGISTER_SUCCESS,
           data
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.AUTH_REGISTER_ERROR,
           error
@@ -116,8 +111,7 @@ let AuthActions = {
           type: ActionTypes.AUTH_VERIFY_SUCCESS,
           data
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.AUTH_VERIFY_ERROR,
           error

--- a/client/scripts/actions/ClientActions.js
+++ b/client/scripts/actions/ClientActions.js
@@ -14,8 +14,7 @@ let ClientActions = {
           type: ActionTypes.CLIENT_SETTINGS_FETCH_REQUEST_SUCCESS,
           data
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_SETTINGS_FETCH_REQUEST_ERROR,
           error
@@ -34,8 +33,7 @@ let ClientActions = {
           data,
           options
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_SETTINGS_SAVE_ERROR,
           error,
@@ -59,8 +57,7 @@ let ClientActions = {
             transferData
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_SET_THROTTLE_ERROR,
           data: {

--- a/client/scripts/actions/FloodActions.js
+++ b/client/scripts/actions/FloodActions.js
@@ -18,8 +18,7 @@ let FloodActions = {
             ...options
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.FLOOD_CLEAR_NOTIFICATIONS_ERROR,
           data: {
@@ -44,8 +43,7 @@ let FloodActions = {
             ...response
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.FLOOD_FETCH_DIRECTORY_LIST_ERROR,
           error
@@ -70,8 +68,7 @@ let FloodActions = {
             ...options
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.FLOOD_FETCH_MEDIAINFO_ERROR,
           error
@@ -97,8 +94,7 @@ let FloodActions = {
             ...options
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.FLOOD_FETCH_NOTIFICATIONS_ERROR,
           data: {
@@ -120,8 +116,8 @@ let FloodActions = {
             transferData
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
+        console.log(error);
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_FETCH_TRANSFER_DATA_ERROR,
           data: {
@@ -143,8 +139,7 @@ let FloodActions = {
         type: ActionTypes.CLIENT_FETCH_TRANSFER_HISTORY_SUCCESS,
         data
       });
-    })
-    .catch((error) => {
+    }, (error) => {
       AppDispatcher.dispatchServerAction({
         type: ActionTypes.CLIENT_FETCH_TRANSFER_HISTORY_ERROR,
         error

--- a/client/scripts/actions/SettingsActions.js
+++ b/client/scripts/actions/SettingsActions.js
@@ -14,8 +14,7 @@ let SettingsActions = {
           type: ActionTypes.SETTINGS_FEED_MONITOR_FEED_ADD_SUCCESS,
           data
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.SETTINGS_FEED_MONITOR_FEED_ADD_ERROR,
           error
@@ -33,8 +32,7 @@ let SettingsActions = {
           type: ActionTypes.SETTINGS_FEED_MONITOR_RULE_ADD_SUCCESS,
           data
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.SETTINGS_FEED_MONITOR_RULE_ADD_ERROR,
           error
@@ -52,8 +50,7 @@ let SettingsActions = {
           type: ActionTypes.SETTINGS_FEED_MONITORS_FETCH_SUCCESS,
           data
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.SETTINGS_FEED_MONITORS_FETCH_ERROR,
           error
@@ -71,8 +68,7 @@ let SettingsActions = {
           type: ActionTypes.SETTINGS_FEED_MONITOR_FEEDS_FETCH_SUCCESS,
           data
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.SETTINGS_FEED_MONITOR_FEEDS_FETCH_ERROR,
           error
@@ -90,8 +86,7 @@ let SettingsActions = {
           type: ActionTypes.SETTINGS_FEED_MONITOR_RULES_FETCH_SUCCESS,
           data
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.SETTINGS_FEED_MONITOR_RULES_FETCH_ERROR,
           error
@@ -109,8 +104,7 @@ let SettingsActions = {
           type: ActionTypes.SETTINGS_FETCH_REQUEST_SUCCESS,
           data
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.SETTINGS_FETCH_REQUEST_ERROR,
           error
@@ -131,8 +125,7 @@ let SettingsActions = {
             id
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.SETTINGS_FEED_MONITOR_REMOVE_ERROR,
           error: {
@@ -154,8 +147,7 @@ let SettingsActions = {
           data,
           options
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.SETTINGS_SAVE_REQUEST_ERROR,
           error

--- a/client/scripts/actions/TorrentActions.js
+++ b/client/scripts/actions/TorrentActions.js
@@ -18,8 +18,7 @@ let TorrentActions = {
             response
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_ADD_TORRENT_ERROR,
           data: {
@@ -43,8 +42,7 @@ let TorrentActions = {
             response
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_ADD_TORRENT_ERROR,
           data: {
@@ -68,8 +66,7 @@ let TorrentActions = {
             deleteData
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_REMOVE_TORRENT_ERROR,
           error: {
@@ -93,8 +90,7 @@ let TorrentActions = {
             count: hash.length
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_CHECK_HASH_ERROR,
           error: {
@@ -117,8 +113,7 @@ let TorrentActions = {
             torrents
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_FETCH_TORRENTS_ERROR,
           data: {
@@ -143,8 +138,7 @@ let TorrentActions = {
             torrentDetails
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_FETCH_TORRENT_DETAILS_ERROR,
           data: {
@@ -164,8 +158,7 @@ let TorrentActions = {
           type: ActionTypes.CLIENT_FETCH_TORRENT_TAXONOMY_SUCCESS,
           data
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_FETCH_TORRENT_TAXONOMY_ERROR,
           error
@@ -183,8 +176,7 @@ let TorrentActions = {
           type: ActionTypes.CLIENT_FETCH_TORRENT_STATUS_COUNT_REQUEST_SUCCESS,
           data
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_FETCH_TORRENT_STATUS_COUNT_REQUEST_ERROR,
           error
@@ -202,8 +194,7 @@ let TorrentActions = {
           type: ActionTypes.CLIENT_FETCH_TORRENT_TRACKER_COUNT_REQUEST_SUCCESS,
           data
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_FETCH_TORRENT_TRACKER_COUNT_REQUEST_ERROR,
           error
@@ -227,8 +218,7 @@ let TorrentActions = {
             count: hashes.length
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_MOVE_TORRENTS_ERROR,
           error
@@ -250,8 +240,7 @@ let TorrentActions = {
             response
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_START_TORRENT_ERROR,
           data: {
@@ -275,8 +264,7 @@ let TorrentActions = {
             response
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_START_TORRENT_ERROR,
           data: {
@@ -300,8 +288,7 @@ let TorrentActions = {
             response
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_STOP_TORRENT_ERROR,
           data: {
@@ -324,8 +311,7 @@ let TorrentActions = {
           type: ActionTypes.CLIENT_SET_TORRENT_PRIORITY_SUCCESS,
           data
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_SET_TORRENT_PRIORITY_ERROR,
           error
@@ -352,8 +338,7 @@ let TorrentActions = {
             priority
           }
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_SET_FILE_PRIORITY_ERROR,
           error
@@ -375,8 +360,7 @@ let TorrentActions = {
           type: ActionTypes.CLIENT_SET_TAXONOMY_SUCCESS,
           data
         });
-      })
-      .catch((error) => {
+      }, (error) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.CLIENT_SET_TAXONOMY_ERROR,
           error


### PR DESCRIPTION
This PR stops catching errors in promises. This was causing errors everywhere in the UI to be swallowed by the promise rejection handlers.