### PR TITLE
Reliably delete data (if requested) when removing torrents

### DIFF
--- a/server/models/Torrent.js
+++ b/server/models/Torrent.js
@@ -66,6 +66,18 @@ class Torrent {
     return Object.assign({}, this.torrentData);
   }
 
+  get directory() {
+    return this.torrentData.directory;
+  }
+
+  get name() {
+    return this.torrentData.name;
+  }
+
+  get isMultiFile() {
+    return this.torrentData.isMultiFile === '1';
+  }
+
   get status() {
     return this.torrentData.status || [];
   }


### PR DESCRIPTION
This PR uses a more reliable method of getting the path of the file to delete. Previously I used the rTorrent's `base_path` property, but it appears this value is available only if the torrent is open (meaning downloading or seeding).

Now, Flood uses the `directory` property which is always available.

Closes #158