### PR TITLE
Fix torrent data deletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "compression": "^1.6.1",
     "cookie-parser": "^1.4.3",
     "debug": "^2.2.0",
-    "del": "^2.2.1",
     "events": "^1.1.0",
     "express": "^4.14.0",
     "feedsub": "^0.3.0",
@@ -35,6 +34,7 @@
     "passport-jwt": "^2.1.0",
     "pug": "^2.0.0-beta3",
     "q": "^1.4.1",
+    "rimraf": "^2.6.1",
     "serve-favicon": "^2.3.0",
     "xmlrpc": "^1.3.0"
   },


### PR DESCRIPTION
This PR uses `rimraf` instead of `del` for deleting files and fixes the bug where files with certain characters weren't deleted. 

Closes https://github.com/jfurrow/flood/issues/158