### PR TITLE
Fix flags alignment

### DIFF
--- a/client/sass/components/_peers-list.scss
+++ b/client/sass/components/_peers-list.scss
@@ -11,7 +11,7 @@
 
     &__image {
       height: 10px;
-      left: 50%;
+      left: 49%;
       position: absolute;
       top: 0;
       transform: translateX(-50%);


### PR DESCRIPTION
Flags in the peer list were centered 1px too far to the right, getting cut-off by `overflow: hidden` of its container - most noticable with Japan's flag.

Before:
![](http://i.imgur.com/9tY2Cnt.png)

After:
![](http://i.imgur.com/TFO0qhL.png)