### PR TITLE
Changed from listening on all interfaces to listening on a specified one

### DIFF
--- a/config.template.js
+++ b/config.template.js
@@ -2,6 +2,7 @@ const CONFIG = {
   baseURI: '/',
   dbCleanInterval: 1000 * 60 * 60,
   dbPath: './server/db/',
+  floodServerHost: '127.0.0.1',
   floodServerPort: 3000,
   maxHistoryStates: 30,
   pollInterval: 1000 * 5,

--- a/server/bin/www
+++ b/server/bin/www
@@ -18,7 +18,9 @@ let debug = require('debug')('flood:server');
 
 // Get port from environment and store in Express.
 let port = normalizePort(config.floodServerPort);
+let host = config.floodServerHost;
 app.set('port', port);
+app.set('host', host);
 
 // Create HTTP or HTTPS server.
 let server;
@@ -39,7 +41,7 @@ if (config.ssl) {
 }
 
 // Listen on provided port, on all network interfaces.
-server.listen(port);
+server.listen(port, host);
 server.on('error', onError);
 server.on('listening', onListening);
 


### PR DESCRIPTION
Enables integration into Webservers proxying the data so the nodejs server is not exposed to the public.