### PR TITLE
Link changelog to diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,5 @@
   * Customizable torrent detail columns
 * Basic torrent list filtering (by status, tag, and tracker)
 * Auto-download torrents from RSS feeds
+
+[1.0.0]:https://github.com/jfurrow/flood/compare/ae520c0a33ffb4ae6f21e47bc6f7e6007dd1e6dc...v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Change Log
+
+## [Unreleased]
+
 ## [1.0.0] (April 21, 2017)
 * First "official" release
 * Change log and semver versioning (finally)
@@ -15,4 +19,5 @@
 * Basic torrent list filtering (by status, tag, and tracker)
 * Auto-download torrents from RSS feeds
 
+[Unreleased]:https://github.com/jfurrow/flood/compare/v1.0.0...HEAD
 [1.0.0]:https://github.com/jfurrow/flood/compare/ae520c0a33ffb4ae6f21e47bc6f7e6007dd1e6dc...v1.0.0


### PR DESCRIPTION
Links the version to its relevant changes diff page - its what the [] are 😉  

Also a good idea to roughly follow [this](http://keepachangelog.com/en/0.3.0/) to ease readability ([example](https://github.com/wopian/hibari/blob/master/CHANGELOG.md)) 👌 