### PR TITLE
Remove verbose messaging in HistoryEra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 * Changed `/list/` route to `/overview/`
 * Reorganized and renamed component source files
+* Removed verbose logging from `HistoryEra`
 
 ## [1.0.0] (April 21, 2017)
 * First "official" release

--- a/server/models/HistoryEra.js
+++ b/server/models/HistoryEra.js
@@ -134,9 +134,7 @@ class HistoryEra {
   removeOutdatedData(db) {
     if (this.opts.maxTime > 0) {
       let minTimestamp = Date.now() - this.opts.maxTime;
-      db.remove({ts: {$lt: minTimestamp}}, {multi: true}, (err, numRemoved) => {
-        console.error(`removed ${numRemoved} entries from ${this.opts.name}`)
-      });
+      db.remove({ts: {$lt: minTimestamp}}, {multi: true});
     }
   }
 


### PR DESCRIPTION
This PR just removes the redundant logging when removing outdated historical data.