### PR TITLE
Add mediainfo for docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:7.8.0-onbuild
-COPY config.docker.js config.js
-
 RUN apt-get update && apt-get install -y mediainfo && rm -rf /var/lib/apt/lists/*
-
+COPY config.docker.js config.js
 EXPOSE 3000
 VOLUME ["/data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:7.8.0-onbuild
 COPY config.docker.js config.js
 
+RUN apt-get update && apt-get install -y mediainfo && rm -rf /var/lib/apt/lists/*
+
 EXPOSE 3000
 VOLUME ["/data"]


### PR DESCRIPTION
In order for mediainfo to work in docker containers we need to install it (obviously^^)