### PR TITLE
Only delete files belonging to torrent

### DIFF
--- a/server/constants/clientRequestServiceEvents.js
+++ b/server/constants/clientRequestServiceEvents.js
@@ -7,6 +7,7 @@ const clientRequestServiceEvents = [
   'PROCESS_TORRENT_LIST_END',
   'PROCESS_TORRENT_LIST_START',
   'PROCESS_TRANSFER_RATE_START',
+  'TORRENTS_REMOVED'
 ];
 
 module.exports = objectUtil.createSymbolMapFromArray(

--- a/server/constants/fileListPropMap.js
+++ b/server/constants/fileListPropMap.js
@@ -1,0 +1,53 @@
+'use strict';
+const fileListPropMap = new Map();
+const defaultTransformer = value => value;
+
+fileListPropMap.set(
+  'path',
+  {
+    methodCall: 'f.path=',
+    transformValue: defaultTransformer
+  }
+);
+
+fileListPropMap.set(
+  'pathComponents',
+  {
+    methodCall: 'f.path_components=',
+    transformValue: defaultTransformer
+  }
+);
+
+fileListPropMap.set(
+  'priority',
+  {
+    methodCall: 'f.priority=',
+    transformValue: defaultTransformer
+  }
+);
+
+fileListPropMap.set(
+  'sizeBytes',
+  {
+    methodCall: 'f.size_bytes=',
+    transformValue: Number
+  }
+);
+
+fileListPropMap.set(
+  'sizeChunks',
+  {
+    methodCall: 'f.size_chunks=',
+    transformValue: Number
+  }
+);
+
+fileListPropMap.set(
+  'completedChunks',
+  {
+    methodCall: 'f.completed_chunks=',
+    transformValue: Number
+  }
+);
+
+module.exports = fileListPropMap;

--- a/server/models/ClientRequest.js
+++ b/server/models/ClientRequest.js
@@ -1,5 +1,9 @@
 'use strict';
 
+/**
+ * This file is deprecated in favor of clientRequestService.
+ */
+
 let mkdirp = require('mkdirp');
 let mv = require('mv');
 let path = require('path');

--- a/server/models/ClientRequest.js
+++ b/server/models/ClientRequest.js
@@ -260,14 +260,6 @@ class ClientRequest {
     });
   }
 
-  removeTorrents(options) {
-    let hashes = this.getEnsuredArray(options.hashes);
-
-    hashes.forEach((hash) => {
-      this.requests.push(this.getMethodCall('d.erase', [hash]));
-    });
-  }
-
   setDownloadPath(options) {
     let hashes = this.getEnsuredArray(options.hashes);
 

--- a/server/models/client.js
+++ b/server/models/client.js
@@ -10,7 +10,6 @@ const clientResponseUtil = require('../util/clientResponseUtil');
 const clientSettingsMap = require('../../shared/constants/clientSettingsMap');
 const ClientRequest = require('./ClientRequest');
 const formatUtil = require('../../shared/util/formatUtil');
-const scgi = require('../util/scgi');
 const TemporaryStorage = require('./TemporaryStorage');
 const torrentFilePropsMap = require('../../shared/constants/torrentFilePropsMap');
 const torrentPeerPropsMap = require('../../shared/constants/torrentPeerPropsMap');
@@ -76,43 +75,6 @@ var client = {
       callback(response, error);
     });
     request.send();
-  },
-
-  deleteTorrents: (options, callback) => {
-    let filesToDelete = null;
-    let eraseTorrentsRequest = new ClientRequest();
-
-    eraseTorrentsRequest.removeTorrents({hashes: options.hashes});
-    eraseTorrentsRequest.onComplete((response, error) => {
-      if (options.deleteData) {
-        const torrents = torrentCollection.torrents;
-
-        options.hashes.forEach(hash => {
-          let fileToDelete = null;
-          const torrent = torrents[hash];
-
-          if (torrent.isMultiFile && torrent.directory != null) {
-            fileToDelete = torrent.directory;
-          } else if (torrent.directory != null && torrent.name != null) {
-            fileToDelete = path.join(torrent.directory, torrent.name);
-          }
-
-          if (fileToDelete != null) {
-            rimraf(fileToDelete, {disableGlob: true}, error => {
-              if (error) {
-                console.error(`Error deleting file: ${fileToDelete}\n${error}`);
-              }
-            });
-          }
-        });
-      }
-
-      torrentService.fetchTorrentList();
-
-      callback(response, error);
-    });
-
-    eraseTorrentsRequest.send();
   },
 
   downloadFiles(hash, files, res) {

--- a/server/routes/client.js
+++ b/server/routes/client.js
@@ -4,6 +4,7 @@ const multer = require('multer');
 
 const ajaxUtil = require('../util/ajaxUtil');
 const client = require('../models/client');
+const clientRequestService = require('../services/clientRequestService');
 const router = express.Router();
 
 const upload = multer({
@@ -65,10 +66,15 @@ router.post('/torrents/move', function(req, res, next) {
 });
 
 router.post('/torrents/delete', function(req, res, next) {
-  let deleteData = req.body.deleteData;
-  let hashes = req.body.hash;
+  const {deleteData, hash: hashes} = req.body;
+  const callback = ajaxUtil.getResponseFn(res);
 
-  client.deleteTorrents({hashes, deleteData}, ajaxUtil.getResponseFn(res));
+  clientRequestService
+    .removeTorrents({hashes, deleteData})
+    .then(callback)
+    .catch((err) => {
+      callback(null, response);
+    });
 });
 
 router.get('/torrents/taxonomy', function(req, res, next) {

--- a/server/services/clientRequestService.js
+++ b/server/services/clientRequestService.js
@@ -52,8 +52,10 @@ class ClientRequestService extends EventEmitter {
         // remove them.
         if (options.deleteData) {
           // We offset the indices of these method calls so that we know exactly
-          // where to retrieve them in the future.
+          // where to retrieve the responses in the future.
           const directoryBaseMethodCallIndex = index + options.hashes.length;
+          // We also need to ensure that the erase method call occurs after
+          // our request for information.
           eraseFileMethodCallIndex = index + options.hashes.length * 2;
 
           accumulator[index] = {

--- a/server/services/historyService.js
+++ b/server/services/historyService.js
@@ -6,27 +6,12 @@ const config = require('../../config');
 const HistoryEra = require('../models/HistoryEra');
 const historyServiceEvents = require('../constants/historyServiceEvents');
 const historySnapshotTypes = require('../../shared/constants/historySnapshotTypes');
+const methodCallUtil = require('../util/methodCallUtil');
 const objectUtil = require('../../shared/util/objectUtil');
 const transferSummaryPropMap = require('../constants/transferSummaryPropMap');
 
-const transferSummaryFetchOptions = Array
-  .from(transferSummaryPropMap.keys())
-  .reduce(
-    (accumulator, key) => {
-      const {methodCall, transformValue} = transferSummaryPropMap.get(key);
-
-      accumulator.methodCalls.push(methodCall);
-      accumulator.propLabels.push(key);
-      accumulator.valueTransformations.push(transformValue);
-
-      return accumulator;
-    },
-    {
-      methodCalls: [],
-      propLabels: [],
-      valueTransformations: []
-    }
-  );
+const transferSummaryMethodCallConfig = methodCallUtil
+  .getMethodCallConfigFromPropMap(transferSummaryPropMap);
 
 const processData = (opts, callback, data, error) => {
   if (error) {
@@ -159,7 +144,7 @@ class HistoryService extends EventEmitter {
     }
 
     clientRequestService
-      .fetchTransferSummary(transferSummaryFetchOptions)
+      .fetchTransferSummary(transferSummaryMethodCallConfig)
       .then(this.handleFetchTransferSummarySuccess.bind(this))
       .catch(this.handleFetchTransferSummaryError.bind(this));
   }

--- a/server/util/methodCallUtil.js
+++ b/server/util/methodCallUtil.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const methodCallUtil = {
+  getMethodCallConfigFromPropMap(map = new Map(), requestedKeys) {
+    let desiredKeys = Array.from(map.keys());
+
+    if (requestedKeys != null) {
+      desiredKeys = desiredKeys.filter(key => requestedKeys.includes(key));
+    }
+
+    return desiredKeys.reduce(
+      (accumulator, key) => {
+        const {methodCall, transformValue} = map.get(key);
+
+        accumulator.methodCalls.push(methodCall);
+        accumulator.propLabels.push(key);
+        accumulator.valueTransformations.push(transformValue);
+
+        return accumulator;
+      },
+      {
+        methodCalls: [],
+        propLabels: [],
+        valueTransformations: []
+      }
+    );
+  }
+};
+
+module.exports = methodCallUtil;


### PR DESCRIPTION
~~(Includes commits from https://github.com/jfurrow/flood/pull/372, which should merge first)~~

This PR will delete only the data that belongs to a specific torrent. With the previous file deletion logic, Flood would try to the torrent's directory if it were a multi-file torrent. This was a problem because rTorrent provides the option to omit the base path when adding a torrent, in which case Flood would delete the torrent's parent directory. You can probably see where this is going...

With this PR, any time a user requests to delete a torrent's data, Flood will first get the list of files from rTorrent, then delete only those files. It should be impossible to delete files which don't belong to the torrent, unless users move files into a torrent's nested directory...