### PR TITLE
Add HTTP2 support to server

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "pug": "^2.0.0-beta3",
     "rimraf": "^2.6.1",
     "serve-favicon": "^2.3.0",
+    "spdy": "^3.4.7",
     "xmlrpc": "^1.3.0"
   },
   "devDependencies": {

--- a/server/bin/www
+++ b/server/bin/www
@@ -32,7 +32,7 @@ if (config.ssl) {
     return;
   }
 
-  server = require('https').createServer({
+  server = require('spdy').createServer({
     key: fs.readFileSync(config.sslKey),
     cert: fs.readFileSync(config.sslCert)
   }, app);


### PR DESCRIPTION
I'm not sure if this is the best way to do it, basically just switched out the express server. It loads everything (html, js, all the assets) as http2.

Page loads don't _feel_ any faster, but the header compression and http2 server push is happening, so it should be slightly faster on slow connections.