### PR TITLE
Display UDP trackers in sidebar

### DIFF
--- a/shared/util/regEx.js
+++ b/shared/util/regEx.js
@@ -2,7 +2,7 @@
 
 const regEx = {
   url: /^(?:https?|ftp):\/\/.{1,}\.{1}.{1,}/,
-  domainName: /https?:\/\/(?:www\.)?([-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,18}\b)*(\/[\/\d\w\.-]*)*(?:[\?])*(.+)*/i
+  domainName: /(?:https?|udp):\/\/(?:www\.)?([-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,18}\b)*(\/[\/\d\w\.-]*)*(?:[\?])*(.+)*/i
 };
 
 module.exports = regEx;


### PR DESCRIPTION
Currently only HTTP or HTTPS trackers are displayed in the sidebar filters.

This pull request adds UDP trackers to the filter.