### PR TITLE
Fixed toolbar not being visible on mobile browsers.

### DIFF
--- a/client/sass/base/_layout.scss
+++ b/client/sass/base/_layout.scss
@@ -27,7 +27,7 @@ body {
     display: flex;
     flex: 1 0 auto;
     flex-direction: column;
-    height: 100vh;
+    height: 100%;
     justify-content: center;
     position: relative;
   }


### PR DESCRIPTION
`vh` unit on mobile browsers includes the width of the address bar, so the toolbar (and part of the torrent list header) are rendered beneath it. On regular websites you can simply scroll and the bar disappears. Not so much with `flood` (and a lot of other similar apps, I guess). Changing the height of the right section from `100vh` to `100%` fixes the issue on mobile and does not change anything on desktop, because everything is absolutely positioned anyway.

Closes: #282 