### PR TITLE
Ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /server/db
 /server/assets/*.map
 /server/temp
+package-lock.json


### PR DESCRIPTION
I don't know what this is except it being created by `npm install`, it blocks my flood gitmodule from being staged by git.