### PR TITLE
Improve Feed logic, enable 'enclosure' feed key support

### DIFF
--- a/server/models/Feed.js
+++ b/server/models/Feed.js
@@ -5,18 +5,20 @@ let FeedSub = require('feedsub');
 class Feed {
   constructor(options) {
     this.options = options || {};
+    this.options.maxItemHistory = options.maxItemHistory || 100;
+    this.items = [];
 
     if (!options.url) {
       console.error('Feed URL must be defined.');
       return null;
     }
 
-    this.items = [];
-    this.maxItemHistory = options.maxItemHistory || 100;
     this.reader = new FeedSub(options.url, {
       autoStart: true,
       emitOnStart: true,
-      interval: options.interval || 15
+      maxHistory: this.options.maxItemHistory,
+      interval: options.interval ? Number(options.interval) : 15,
+      readEveryItem: true
     });
 
     this.initReader();
@@ -26,20 +28,20 @@ class Feed {
     return this.items;
   }
 
-  handleFeedItem(item) {
-    let arrayAction = 'push';
-
-    if (this.items.length >= this.maxItemHistory) {
-      arrayAction = 'shift';
+  handleFeedItems(items) {
+    const nextLength = this.items.length + items.length;
+    if (nextLength >= this.options.maxItemHistory) {
+      const diff = nextLength - this.options.maxHistory;
+      this.items = this.items.splice(0, diff);
     }
 
-    this.items[arrayAction](item);
+    this.items = this.items.concat(items);
 
-    this.options.onNewItem({feed: this.options, torrent: item});
+    this.options.onNewItems({feed: this.options, items});
   }
 
   initReader() {
-    this.reader.on('item', this.handleFeedItem.bind(this));
+    this.reader.on('items', this.handleFeedItems.bind(this));
     this.reader.on('error', error => {
       console.log('Feed reader error:', error);
     });

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -22,18 +22,23 @@ class NotificationService extends EventEmitter {
     this.countNotifications();
   }
 
-  addNotification(notification) {
-    this.count.total++;
-    this.count.unread++;
+  addNotification(notifications) {
+    notifications = _.castArray(notifications);
 
-    this.db.insert({
-      ts: Date.now(),
-      data: notification.data,
-      id: notification.id,
-      read: false
+    this.count.total = this.count.total + notifications.length;
+    this.count.unread = this.count.unread + notifications.length;
+
+    const timestamp = Date.now();
+    const notificationsToInsert = notifications.map(notification => {
+      return {
+        ts: timestamp,
+        data: notification.data,
+        id: notification.id,
+        read: false
+      };
     });
 
-    this.emitUpdate();
+    this.db.insert(notificationsToInsert, () => this.emitUpdate());
   }
 
   clearNotifications(options, callback) {


### PR DESCRIPTION
This is a slight refactor to `feedService`.
* Fixes a bug when adding a rule against existing feed. Now the new rule will be applied to all existing feed items
* Looks for `enclosure` value in a feed item, which sometimes contains multiple URLs, if `link` value is falsy

Fixes https://github.com/jfurrow/flood/issues/433

@SanPilot want to try this out? This should address the same thing that your PR addressed.