### PR TITLE
darker menu item foreground

### DIFF
--- a/client/src/sass/components/_base-menu.scss
+++ b/client/src/sass/components/_base-menu.scss
@@ -6,7 +6,7 @@ $menu--value: #8899a8;
 $menu--value--active: #4e6a7c;
 $menu--header--border: rgba($sidebar--background, 0.05);
 $menu--item--background--hover: rgba($main-content--background, 0.4);
-$menu--item--foreground: #95a2ad;
+$menu--item--foreground: #526780;
 $menu--item--foreground--hover: darken($menu--item--foreground, 10%);
 $menu--item--secondary--foreground: lighten($menu--item--foreground, 20%);
 $menu--item--foreground--active: $blue;


### PR DESCRIPTION
On different LCD screens,  I couldn't actually read this text, as it is too light.

The new colour is taken from the side bar.