### PR TITLE
[RSS Feeds] Always get items from enclosures

### DIFF
--- a/server/services/feedService.js
+++ b/server/services/feedService.js
@@ -147,14 +147,18 @@ class FeedService {
 
   // TODO: Allow users to specify which key contains the URLs.
   getTorrentUrlsFromItem(feedItem) {
+
+    // Combine items from link tag and enclosures
+    let items = [];
+
     if (feedItem.link) {
-      return [feedItem.link];
+      items.push(feedItem.link);
     }
 
     // If we've got an Array of enclosures, we'll iterate over the values and
     // look for the url key.
     if (feedItem.enclosures && Array.isArray(feedItem.enclosures)) {
-      return feedItem.enclosures.reduce(
+      items.concat(feedItem.enclosures.reduce(
         (urls, enclosure) => {
           if (enclosure.url) {
             urls.push(enclosure.url);
@@ -163,10 +167,11 @@ class FeedService {
           return urls;
         },
         []
-      );
+      ));
     }
 
-    return [];
+    // Return the combined list
+    return items;
   }
 
   getUrlsFromItems(feedItems) {


### PR DESCRIPTION
The current behavior of the Feed service is to skip torrents from the enclosures if there is a `link` element. However, on many feeds, this doesn't work correctly.

For example, [the Arch Linux RSS feed](https://www.archlinux.org/feeds/releases/) uses the `link` tag to link to a web page with information about the download. The actual torrent URLs are in the enclosure tags.

This PR changes the behavior to include items from both the link tag and the enclosure tags.