### PR TITLE
[RSS Feeds] Prefer enclosures over link tag

### DIFF
--- a/server/services/feedService.js
+++ b/server/services/feedService.js
@@ -147,10 +147,6 @@ class FeedService {
 
   // TODO: Allow users to specify which key contains the URLs.
   getTorrentUrlsFromItem(feedItem) {
-    if (feedItem.link) {
-      return [feedItem.link];
-    }
-
     // If we've got an Array of enclosures, we'll iterate over the values and
     // look for the url key.
     if (feedItem.enclosures && Array.isArray(feedItem.enclosures)) {
@@ -164,6 +160,11 @@ class FeedService {
         },
         []
       );
+    }
+
+    // If there are no enclosures, then use the link tag instead
+    if (feedItem.link) {
+      return [feedItem.link];
     }
 
     return [];


### PR DESCRIPTION
Changes behavior of Feed Service to only use link tag if there are no enclosures.

This makes sense because trackers that use enclosures put the torrent's URLs in them (usually, the `link` tag is for humans). If the tracker doesn't have enclosures, the `link` tag is where the URL goes.

This is also how [ruTorrent's RSS plugin does it](https://github.com/Novik/ruTorrent/blob/c5bc4f7831b568084fff0cff8b52223ee61ee335/plugins/rss/rss.php#L209)