### PR TITLE
Fixed sizes > 1TB displaying as GB.

### DIFF
--- a/client/src/javascript/util/size.js
+++ b/client/src/javascript/util/size.js
@@ -44,7 +44,7 @@ export function getTranslationString(unit) {
     kB: 'unit.size.kilobyte',
     MB: 'unit.size.megabyte',
     GB: 'unit.size.gigabyte',
-    TB: 'unit.size.gigabyte',
+    TB: 'unit.size.terabyte',
   };
 
   return UNIT_TO_STRING_ID[unit] || 'unit.size.byte';


### PR DESCRIPTION
While refactoring the `Size` component into a util, I must've missed changing one translation string after copy-pasting it from somewhere else.
Here comes the fix.

Closes: #504 