### PR TITLE
Use argon2 for password hashing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -179,6 +179,11 @@
         "color-convert": "1.9.0"
       }
     },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+    },
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
@@ -214,6 +219,16 @@
       "requires": {
         "delegates": "1.0.0",
         "readable-stream": "2.3.3"
+      }
+    },
+    "argon2": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.16.2.tgz",
+      "integrity": "sha512-R9IcqgINNGsMdLNHUkVEtKGSDrnGYvGbdg2h9Agldhfx013G5ssrPVgvf6poC9yd2+flHiPQlOxO4+/qAfprhA==",
+      "requires": {
+        "any-promise": "1.3.0",
+        "bindings": "1.3.0",
+        "nan": "2.6.2"
       }
     },
     "argparse": {
@@ -1503,6 +1518,11 @@
       "requires": {
         "underscore": "1.4.4"
       }
+    },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
     "bl": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "start:development:client": "node client/scripts/start.js"
   },
   "dependencies": {
+    "argon2": "^0.16.2",
     "autoprefixer": "^7.1.2",
     "axios": "^0.16.2",
     "babel-core": "6.25.0",


### PR DESCRIPTION
This PR implements [argon2](https://github.com/ranisalt/node-argon2) for password hashing. Closes #514 

**I'm proposing to keep the bcrypt dependency for a while** to allow for a smooth "migration" period, but I'm open to other ideas if anyone has qualms with this.

When an existing user authenticates, Flood will attempt to validate the password using argon2. If this fails, it will attempt to validate with bcrypt. If the bcrypt validation is successful, then Flood will hash the provided password with argon2 and update the database, replacing the bcrypt hash — this "migrates" the user's database entry from bcrypt to argon2. If both argon2 and bcrypt validations fail, then it's just a failed login attempt.

All new users will use argon2 hashes.