### PR TITLE
Use width instead of transform in ProgressBar

### DIFF
--- a/client/src/javascript/components/general/ProgressBar.js
+++ b/client/src/javascript/components/general/ProgressBar.js
@@ -1,26 +1,12 @@
 import React from 'react';
 
-let cachedProgressBars = {};
-
-export default class ProgressBar extends React.Component {
+export default class ProgressBar extends React.PureComponent {
   render() {
-    let {percent} = this.props;
-    let progressBar;
+    const percent = Math.round(this.props.percent);
+    const style = {};
 
-    if (cachedProgressBars[percent] != null) {
-      progressBar = cachedProgressBars[percent];
-    } else {
-      let style = {};
-
-      if (percent !== 100) {
-        style = {transform: `scaleX(${percent / 100})`};
-      }
-
-      progressBar = (
-        <div className="progress-bar__fill__wrapper">
-          <div className="progress-bar__fill" style={style} />
-        </div>
-      );
+    if (percent !== 100) {
+      style.width = `${percent}%`;
     }
 
     return (
@@ -28,7 +14,9 @@ export default class ProgressBar extends React.Component {
         <div className="progress-bar__icon">
           {this.props.icon}
         </div>
-        {progressBar}
+        <div className="progress-bar__fill__wrapper">
+          <div className="progress-bar__fill" style={style} />
+        </div>
       </div>
     );
   }

--- a/client/src/sass/components/_progress-bar.scss
+++ b/client/src/sass/components/_progress-bar.scss
@@ -82,8 +82,6 @@ $progress-bar--track--background--selected: rgba(#fff, 0.15);
     background: $progress-bar--fill;
     display: block;
     height: $progress-bar--height;
-    transform-origin: 0 0;
-    transition: transform 0.25s;
     width: 100%;
 
     .torrent--is-seeding & {


### PR DESCRIPTION
Closes #517 (hopefully)

* Uses `width` instead of `transform` and removes the `transition`
* Removes progress bar caching, as it was only caching a few DOM nodes — not sure why I thought this would be helpful