### PR TITLE
Fix hash checking experience

### DIFF
--- a/server/models/ClientRequest.js
+++ b/server/models/ClientRequest.js
@@ -185,15 +185,24 @@ class ClientRequest {
 
   checkHash(options) {
     const hashes = this.getEnsuredArray(options.hashes);
-    const hashesToStop = hashes.filter(hash => {
+    const stoppedHashes = hashes.filter(hash => {
       return torrentService.getTorrent(hash).status.includes(torrentStatusMap.stopped);
     });
+    const hashesToStart = [];
+
+    this.stopTorrents({ hashes });
 
     hashes.forEach(hash => {
       this.requests.push(this.getMethodCall('d.check_hash', [hash]));
+
+      if (!stoppedHashes.includes(hash)) {
+        hashesToStart.push(hash);
+      }
     });
 
-    this.stopTorrents({hashes: hashesToStop});
+    if (hashesToStart.length) {
+      this.startTorrents({ hashes: hashesToStart });
+    }
   }
 
   createDirectory(options) {

--- a/server/services/torrentService.js
+++ b/server/services/torrentService.js
@@ -156,14 +156,14 @@ class TorrentService extends EventEmitter {
       torrentStatus.push(torrentStatusMap.complete);
       torrentStatus.push(torrentStatusMap.seeding);
     } else if (isComplete && isOpen && state === '0') {
-      torrentStatus.push(torrentStatusMap.paused);
+      torrentStatus.push(torrentStatusMap.stopped);
     } else if (isComplete && !isOpen) {
       torrentStatus.push(torrentStatusMap.stopped);
       torrentStatus.push(torrentStatusMap.complete);
     } else if (!isComplete && isOpen && state === '1') {
       torrentStatus.push(torrentStatusMap.downloading);
     } else if (!isComplete && isOpen && state === '0') {
-      torrentStatus.push(torrentStatusMap.paused);
+      torrentStatus.push(torrentStatusMap.stopped);
     } else if (!isComplete && !isOpen) {
       torrentStatus.push(torrentStatusMap.stopped);
     }


### PR DESCRIPTION
## Description
1. When initiating a file hash check, Flood will tell rtorrent to "stop" the selected torrents (by invoking RPC commands `d.stop` and `d.close`). If the torrent was _not_ previously considered `stopped` (by [these disorderly conditions](https://github.com/jfurrow/flood/blob/dc0fea927967ea1197b855f290769a2a9047ab5d/server/services/torrentService.js#L153-L169), then it will "start" the selected torrents (by invoking RPC commands `d.open` and `d.start` immediately after `d.check_hash`).
2. Flood previously differentiated between "stopped" and "paused" torrents based on the `d.is_open` response, but with this PR, it will consider "paused" torrents to be "stopped" as well, which seems to better represent their behavior in rtorrent. I'm not sure if this is the best idea, or if the traits that make up the "paused" status could be meaningful — it's unclear to me what `d.is_open` represents. Probably it's something to do with the filesystem? [These docs](https://github.com/mdevaev/emonoda/wiki/rTorrent-XMLRPC-Reference) offer this vague description: `Get the state of the torrent (0=closed, 1=open)`. I'm open to suggestions here; surely `d.is_open` presents something meaningful, but from what I can tell, the Flood UI doesn't need to communicate this.

These two changes fix the bug with Flood's "check hash" logic for non-"stopped" torrents and the erroneous "downloading" state in the UI after performing "check hash" on a stopped torrent.

## Related Issue
Closes https://github.com/jfurrow/flood/issues/537

## Motivation and Context
The current behavior is broken as described in the issue.

## How Has This Been Tested?
Tested manually against "stopped" and "downloading" torrents.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
