### PR TITLE
Fix erroneous stringified boolean value interpretation

### DIFF
--- a/server/middleware/booleanCoerce.js
+++ b/server/middleware/booleanCoerce.js
@@ -2,7 +2,7 @@
 
 module.exports = key => {
   return (req, res, next) => {
-    const value = req.body[key];
+    const value = req.body && req.body[key];
 
     if (value && typeof value === 'string') {
       req.body[key] = value === 'true';

--- a/server/middleware/booleanCoerce.js
+++ b/server/middleware/booleanCoerce.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = key => {
+  return (req, res, next) => {
+    const value = req.body[key];
+
+    if (value && typeof value === 'string') {
+      req.body[key] = value === 'true';
+    }
+
+    next();
+  };
+};

--- a/server/routes/client.js
+++ b/server/routes/client.js
@@ -3,6 +3,7 @@ const express = require('express');
 const multer = require('multer');
 
 const ajaxUtil = require('../util/ajaxUtil');
+const booleanCoerce = require('../middleware/booleanCoerce');
 const client = require('../models/client');
 const clientRequestService = require('../services/clientRequestService');
 const router = express.Router();
@@ -17,9 +18,14 @@ router.post('/add', function(req, res, next) {
   client.addUrls(req.body, ajaxUtil.getResponseFn(res));
 });
 
-router.post('/add-files', upload.array('torrents'), function(req, res, next) {
-  client.addFiles(req, ajaxUtil.getResponseFn(res));
-});
+router.post(
+  '/add-files',
+  upload.array('torrents'),
+  booleanCoerce('isBasePath'),
+  function(req, res, next) {
+    client.addFiles(req, ajaxUtil.getResponseFn(res));
+  }
+);
 
 router.get('/settings', function(req, res, next) {
   client.getSettings(req.query, ajaxUtil.getResponseFn(res));


### PR DESCRIPTION
## Description
When uploading files, a [`FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData) instance is used to submit the torrent files and options. `FormData.append` stringifies boolean values, so Flood interpreted `isBasePath: 'false'` as truthy, and used the destination as the torrent's base path.

* Adds `coerceBoolean` middleware
* Implements the middleware for `isBasePath` value

## Related Issue
Fixes https://github.com/jfurrow/flood/issues/390

## Motivation and Context
Bad bug

## How Has This Been Tested?
Added torrents by file & URL

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
