### PR TITLE
Fix button loading indicators

### DIFF
--- a/client/src/sass/components/_icons.scss
+++ b/client/src/sass/components/_icons.scss
@@ -19,8 +19,6 @@
 }
 
 .icon {
-  height: 15px;
-  width: 15px;
 
   &--eta {
 


### PR DESCRIPTION
## Description
Remove global icon width/height which was breaking the loading indicators in buttons. I don't think any icons relied on this to display properly, but I might be wrong. 

## Motivation and Context
It looked like 💩

## How Has This Been Tested?
I looked through the UI and everything seemed fine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
