### PR TITLE
Show correct peer encryption status

### DIFF
--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.js
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.js
@@ -31,7 +31,7 @@ export default class TorrentPeers extends React.Component {
       const {erroredCountryImages} = this.state;
       const peerList = peers.map((peer, index) => {
         const {country: countryCode} = peer;
-        const encryptedIcon = peer.isEncrypted === "1" ? checkmark : null;
+        const encryptedIcon = peer.isEncrypted ? checkmark : null;
         let peerCountry = null;
 
         if (countryCode) {

--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.js
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.js
@@ -31,7 +31,7 @@ export default class TorrentPeers extends React.Component {
       const {erroredCountryImages} = this.state;
       const peerList = peers.map((peer, index) => {
         const {country: countryCode} = peer;
-        const encryptedIcon = peer.isEncrypted ? checkmark : null;
+        const encryptedIcon = peer.isEncrypted === "1" ? checkmark : null;
         let peerCountry = null;
 
         if (countryCode) {

--- a/server/util/clientResponseUtil.js
+++ b/server/util/clientResponseUtil.js
@@ -94,6 +94,11 @@ let clientResponseUtil = {
       ).map((peer) => {
         let geoData = geoip.lookup(peer.address) || {};
         peer.country = geoData.country;
+
+        // Strings to boolean
+        peer.isEncrypted = peer.isEncrypted === '1';
+        peer.isIncoming = peer.isIncoming === '1';
+
         return peer;
       });
     }

--- a/shared/constants/torrentPeerPropsMap.js
+++ b/shared/constants/torrentPeerPropsMap.js
@@ -11,7 +11,7 @@ const torrentPeerPropsMap = {
     'uploadTotal',
     'id',
     'peerRate',
-    'peerTotal',,
+    'peerTotal',
     'isEncrypted',
     'isIncoming'
   ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
2 Changes
- [x] 'isEncrypted' is string, not boolean, so check for exact string value
- [ ] For some reason (that I can't yet figure out) the 'isEncrypted' string is always '0', even when the connection is encrypted
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #574
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Reports correct encryption status in torrent details.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested yet.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
