### PR TITLE
Set username in AuthStore on login

### DIFF
--- a/client/src/javascript/actions/AuthActions.js
+++ b/client/src/javascript/actions/AuthActions.js
@@ -9,6 +9,7 @@ const baseURI = ConfigStore.getBaseURI();
 let AuthActions = {
   authenticate: (credentials) => {
     return axios.post(`${baseURI}auth/authenticate`, credentials)
+      .then((json = {}) => json.data)
       .then((data) => {
         AppDispatcher.dispatchServerAction({
           type: ActionTypes.AUTH_LOGIN_SUCCESS,

--- a/client/src/javascript/stores/AuthStore.js
+++ b/client/src/javascript/stores/AuthStore.js
@@ -79,6 +79,7 @@ class AuthStoreClass extends BaseStore {
 
   handleLoginSuccess(data) {
     this.emit(EventTypes.AUTH_LOGIN_SUCCESS);
+    this.currentUser.username = data.username;
     this.token = data.token;
   }
 


### PR DESCRIPTION
The username was not stored on login.

## Motivation and Context
`AuthStore` did not store username after a successful `/authenticate` request

## How Has This Been Tested?
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
