### PR TITLE
deleteData will also remove empty baseDirs

### DIFF
--- a/server/services/clientRequestService.js
+++ b/server/services/clientRequestService.js
@@ -133,13 +133,7 @@ class ClientRequestService extends EventEmitter {
               }
               if (counter === array.length) {
                 filesToDelete.dirs.forEach(dir => {
-                  fs.readdir(dir, (err, files) => {
-                    if (err) {} else {
-                      if (!files.length) {
-                        fs.rmdir(dir, err => {});
-                      }
-                    }
-                  });
+                  fs.rmdir(dir, err => {});
                 });
               }
             });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When remove torrents from rtorrent with deleteData checked, the base directories will be removed if they are empty. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/jfurrow/flood/issues/466

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
More comfortable without empty dirs left.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The code is modified based on the git version, tested on my local PC Archlinux with rtorrent 0.9.6. My changes will check the base directory when a torrent is removed with intention to delete the files on disk. If the directory is empty, it will also be revomed. I tested with several torrents and it acts as what I described.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
