### PR TITLE
Fix torrent sorting for some string props

### DIFF
--- a/client/src/javascript/util/sortTorrents.js
+++ b/client/src/javascript/util/sortTorrents.js
@@ -1,4 +1,7 @@
 // TODO: Split up this garbage.
+
+const stringProps = ['basePath', 'comment', 'hash', 'message', 'name'];
+
 export function sortTorrents(torrentsHash, sortBy) {
   let torrents = Object.keys(torrentsHash).map((hash) => {
     return {hash, ...torrentsHash[hash]};
@@ -38,13 +41,13 @@ export function sortTorrents(torrentsHash, sortBy) {
         if (valB !== 'Infinity') {
           valB = Number(valB.cumSeconds);
         }
-      } else if (property === 'name') {
-        valA = valA.toLowerCase();
-        valB = valB.toLowerCase();
       } else if (property === 'tags') {
         // TODO: Find a better way to sort tags.
         valA = valA.join(',').toLowerCase();
         valB = valB.join(',').toLowerCase();
+      } else if (stringProps.includes(property)) {
+        valA = valA.toLowerCase();
+        valB = valB.toLowerCase();
       } else {
         valA = Number(valA);
         valB = Number(valB);


### PR DESCRIPTION
## Description
* Prevents `sortTorrents` from casting these string props as numbers before sorting

## Related Issue
Closes https://github.com/jfurrow/flood/issues/536

## Motivation and Context
See issue

## How Has This Been Tested?
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
