### PR TITLE
Fixed bug where tags were not able to be removed

### DIFF
--- a/client/src/javascript/components/modals/set-tags-modal/SetTagsModal.js
+++ b/client/src/javascript/components/modals/set-tags-modal/SetTagsModal.js
@@ -18,12 +18,10 @@ class SetTagsModal extends React.Component {
     const formData = this.formRef.getFormData();
     const tags = formData.tags ? formData.tags.split(',') : [];
 
-    if (tags && tags.length > 0) {
-      this.setState(
-        {isSettingTags: true},
-        () => TorrentActions.setTaxonomy(TorrentStore.getSelectedTorrents(), tags)
-      );
-    }
+    this.setState(
+      {isSettingTags: true},
+      () => TorrentActions.setTaxonomy(TorrentStore.getSelectedTorrents(), tags)
+    );
   };
 
   getActions() {


### PR DESCRIPTION
## Description
The reason tags were not able to be removed was a check during the submission of the tag editing form.
This check prevented the editing of the tags when no tags were entered.
The fix was simply to remove the check, but this might introduce new issues.

## Related Issue
See #521

## Motivation and Context
See #521

## How Has This Been Tested?
I tested the fix by adding and removing tags.
I also entered some unusual inputs:
- several and single spaces
- several and single commas

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
