### PR TITLE
Remove useless comma

### DIFF
--- a/config.template.js
+++ b/config.template.js
@@ -44,7 +44,7 @@ const CONFIG = {
   // Configuration for SSL, if using SSL with the Flood service directly.
   ssl: false,
   sslKey: '/absolute/path/to/key/',
-  sslCert: '/absolute/path/to/certificate/',
+  sslCert: '/absolute/path/to/certificate/'
 };
 // Do not remove the below line.
 module.exports = CONFIG;


### PR DESCRIPTION
Just a typo fix.

## Description
I removed an useless comma in the configuration template.

## Related Issue
n/a

## Motivation and Context
My OCD now feels better.

## How Has This Been Tested?
Rebuild and run on Ubuntu 17.10.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.