### PR TITLE
Fix wrong SCGI XML-RPC body length calculation method

### DIFF
--- a/server/util/scgi.js
+++ b/server/util/scgi.js
@@ -33,11 +33,12 @@ const sendMethodCall = (methodName, parameters) => {
     const deserializer = new Deserializer('utf8');
     const stream = net.connect(connectMethod);
     const xml = Serializer.serializeMethodCall(methodName, parameters);
+    const xmlLength = Buffer.byteLength(xml, 'utf8');
 
     stream.setEncoding('UTF8');
 
     const headerItems = [
-      `CONTENT_LENGTH${nullChar}${xml.length}${nullChar}`,
+      `CONTENT_LENGTH${nullChar}${xmlLength}${nullChar}`,
       `SCGI${nullChar}1${nullChar}`
     ];
 


### PR DESCRIPTION
Fix wrong XML-RPC body length calculation method which results in SCGI calls failing when multibyte characters are included.

## Description
I discovered that flood calculates XML-RPC body length of an SCGI call simply by using String.prototype.length. This works ok when all payload is consist of single-byte characters. 

However, when any multibyte character is included in xml payload, it miscalculate body length as JavaScript's string is UTF-16 and every UTF-8 multibyte characters are single-byte in UTF-16. So while String.prototype.length reports that the length of a UTF-8 character is 1, it may be 2-4 bytes when encoded in UTF-8, which causes rTorrent's XML-RPC server to misbehave.

`[Error: XML-RPC fault: Call XML not a proper XML-RPC call.  Call is not valid XML.  Invalid XML "content".  Problem with token at '<...': unclosed token]`

This error is thrown when UTF-8 multibyte character is included in XML body, as current implementation of SCGI call builder reports shorter body length than its actual length.

I fixed this issue by calculating body length properly using Node's Buffer.byteLength function, which returns real byte length of UTF-8 encoded string.

## Related Issue
#164 #196 

I think changes in #196 may be reverted, but not tested.

## Motivation and Context
I faced this issue when I tried to add torrents with download path including CJK characters. I wasn't able to use flood since my hard drive is full of directories containing UTF-8 multibyte characters and flood couldn't handle it.

This PR fixes issues with CJK character handling.

## How Has This Been Tested?
I'm running the modified source on my machine for several days with bunch of torrents with multibyte character path. No problem so far.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
