### PR TITLE
Fix 'Download' button in newer Firefox versions

### DIFF
--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentFiles.js
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentFiles.js
@@ -98,6 +98,8 @@ class TorrentFiles extends React.Component {
     const link = document.createElement('a');
     link.download = `${this.props.torrent.name}.tar`;
     link.href = `${baseURI}api/download?hash=${this.props.torrent.hash}&files=${this.state.selectedFiles.join(',')}`;
+    link.style.display = 'none';
+    document.body.appendChild(link); // Fix for Firefox 58+
     link.click();
   };
 

--- a/client/src/javascript/components/torrent-list/TorrentList.js
+++ b/client/src/javascript/components/torrent-list/TorrentList.js
@@ -322,6 +322,8 @@ class TorrentListContainer extends React.Component {
     const link = document.createElement('a');
     link.download = torrent.isMultiFile ? `${torrent.name}.tar` : torrent.name;
     link.href = `${baseURI}api/download?hash=${torrent.hash}`;
+    link.style.display = 'none';
+    document.body.appendChild(link);
     link.click();
   }
 


### PR DESCRIPTION
The element is set to `display: none` before being appended to the document.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Support behavior in Firefox 58+ where links cannot be clicked unless they are in the document.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See #579 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Download button is completely broken in Firefox 58+

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing and working in Firefox 60 and Chrome 66.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
