### PR TITLE
Rate graph: use monotone interpolation to prevent Gibbs phenomenon

### DIFF
--- a/client/src/javascript/components/sidebar/TransferRateGraph.js
+++ b/client/src/javascript/components/sidebar/TransferRateGraph.js
@@ -162,10 +162,11 @@ class TransferRateGraph extends React.Component {
       .interpolate(interpolation);
     };
 
-    const downloadLinePath = lineFunc('cardinal')(historicalData.download);
-    const downloadAreaShape = areaFunc('cardinal')(historicalData.download);
-    const uploadLinePath = lineFunc('cardinal')(historicalData.upload);
-    const uploadAreaShape = areaFunc('cardinal')(historicalData.upload);
+    const interpolation = 'monotone';
+    const downloadLinePath = lineFunc(interpolation)(historicalData.download);
+    const downloadAreaShape = areaFunc(interpolation)(historicalData.download);
+    const uploadLinePath = lineFunc(interpolation)(historicalData.upload);
+    const uploadAreaShape = areaFunc(interpolation)(historicalData.upload);
 
     if (!this.graphRefs.areDefined) {
       this.appendEmptyGraphShapes(graph, 'download');


### PR DESCRIPTION
See screenshots. tl;dr removed ripples by changing the graph interpolation function.

## Description
The current d3 interpolation function for the rate graph is *cardinal*. While seemingly okay, this function creates some [Gibbs phenomenon ripples](https://en.wikipedia.org/wiki/Gibbs_phenomenon) which give impossible rates when displaying steep curves (typically a negative speed when a download starts/ends).

Going with *monotone* gives the exact same curve *feeling* while removing the ripples.

## Motivation and Context
These ripples look terrible and are easily avoidable.

## How Has This Been Tested?
Locally.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/81353/44959643-0e4c4c00-aef2-11e8-9bcb-816f3edd122f.png)
![image](https://user-images.githubusercontent.com/81353/44959601-81a18e00-aef1-11e8-8456-45f7fe0424ba.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
