### PR TITLE
Avoid errors when a flag image is missing

### DIFF
--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.js
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.js
@@ -43,8 +43,7 @@ export default class TorrentPeers extends React.Component {
             let flagImageSrc;
             try {
               flagImageSrc = require(`../../../../images/flags/${countryCode.toLowerCase()}.png`);
-            }
-            catch(e) {
+            } catch {
               this.flagImageAsErrored(countryCode);
               flagImageSrc = null;
             }

--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.js
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.js
@@ -43,7 +43,7 @@ export default class TorrentPeers extends React.Component {
             let flagImageSrc;
             try {
               flagImageSrc = require(`../../../../images/flags/${countryCode.toLowerCase()}.png`);
-            } catch {
+            } catch (err) {
               this.flagImageAsErrored(countryCode);
               flagImageSrc = null;
             }

--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.js
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.js
@@ -16,12 +16,14 @@ export default class TorrentPeers extends React.Component {
     };
   }
 
+  flagImageAsErrored(countryCode) {
+    let {erroredCountryImages} = this.state;
+    erroredCountryImages.push(countryCode);
+    this.setState({erroredCountryImages});
+  }
+
   getImageErrorHandlerFn(countryCode) {
-    return () => {
-      let {erroredCountryImages} = this.state;
-      erroredCountryImages.push(countryCode);
-      this.setState({erroredCountryImages});
-    };
+    return () => this.flagImageAsErrored(countryCode);
   }
 
   render() {
@@ -43,7 +45,7 @@ export default class TorrentPeers extends React.Component {
               flagImageSrc = require(`../../../../images/flags/${countryCode.toLowerCase()}.png`);
             }
             catch(e) {
-              this.getImageErrorHandlerFn(countryCode);
+              this.flagImageAsErrored(countryCode);
               flagImageSrc = null;
             }
 

--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.js
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentPeers.js
@@ -38,16 +38,25 @@ export default class TorrentPeers extends React.Component {
           let image = null;
 
           if (!erroredCountryImages.includes(countryCode)) {
-            const flagImageSrc = require(`../../../../images/flags/${countryCode.toLowerCase()}.png`);
+            let flagImageSrc;
+            try {
+              flagImageSrc = require(`../../../../images/flags/${countryCode.toLowerCase()}.png`);
+            }
+            catch(e) {
+              this.getImageErrorHandlerFn(countryCode);
+              flagImageSrc = null;
+            }
 
-            image = (
-              <img
-                alt={countryCode}
-                className="peers-list__flag__image"
-                onError={this.getImageErrorHandlerFn(countryCode)}
-                src={flagImageSrc}
-              />
-            );
+            if (flagImageSrc) {
+              image = (
+                <img
+                  alt={countryCode}
+                  className="peers-list__flag__image"
+                  onError={this.getImageErrorHandlerFn(countryCode)}
+                  src={flagImageSrc}
+                />
+              );
+            }
           }
 
           peerCountry = (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Display the country code instead of the picture when country flag is missing.

## Related Issue
Fix #677.

## Motivation and Context
See issue.

## How Has This Been Tested?
Run with Node 8.11.2 on Ubuntu 17.10, tested with Safari 12.0 (13606.2.11) and Chrome 69.0.3497.100 on macOS 10.13.6.

## Screenshots (if appropriate):
![capture d ecran 2018-09-22 a 19 11 19](https://user-images.githubusercontent.com/90145/45919794-6811b780-be9b-11e8-915b-59f58dadf8b9.png)

(I deleted the 'fr.png' file to test my fix)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.