### PR TITLE
Attempts to fix failing settings request

### DIFF
--- a/client/src/javascript/app.js
+++ b/client/src/javascript/app.js
@@ -44,9 +44,6 @@ class FloodApp extends React.Component {
 
   componentDidMount() {
     SettingsStore.listen(EventTypes.SETTINGS_CHANGE, this.handleSettingsChange);
-
-    SettingsStore.fetchClientSettings();
-    SettingsStore.fetchFloodSettings();
   }
 
   componentWillUnmount() {

--- a/client/src/javascript/components/AppWrapper.js
+++ b/client/src/javascript/components/AppWrapper.js
@@ -12,6 +12,7 @@ import ClientConnectionInterruption from './general/ClientConnectionInterruption
 import EventTypes from '../constants/EventTypes';
 import FloodActions from '../actions/FloodActions';
 import LoadingIndicator from './general/LoadingIndicator';
+import SettingsStore from '../stores/SettingsStore';
 import UIStore from '../stores/UIStore';
 import WindowTitle from './general/WindowTitle';
 
@@ -92,6 +93,8 @@ class AuthEnforcer extends React.Component {
       browserHistory.replace('register');
     } else {
       this.setState({authStatusDetermined: true, isAuthenticated: true});
+      SettingsStore.fetchClientSettings();
+      SettingsStore.fetchFloodSettings();
       browserHistory.replace('overview');
     }
   }

--- a/client/src/javascript/components/AppWrapper.js
+++ b/client/src/javascript/components/AppWrapper.js
@@ -1,7 +1,6 @@
 import {browserHistory} from 'react-router';
 import classnames from 'classnames';
 import CSSTransitionGroup from 'react-addons-css-transition-group';
-import {FormattedMessage} from 'react-intl';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -40,14 +39,7 @@ class AuthEnforcer extends React.Component {
 
     this.state = {
       authStatusDetermined: false,
-      dependencies: {
-        authentication: {
-          message: (
-            <FormattedMessage id="dependency.loading.authentication.status" defaultMessage="Authentication Status" />
-          ),
-          satisfied: false,
-        },
-      },
+      dependencies: {},
       isAuthenticated: false,
       isClientConnected: false,
       dependenciesLoaded: false,
@@ -145,15 +137,7 @@ class AuthEnforcer extends React.Component {
 
   handleUIDependenciesChange() {
     this.setState({
-      dependencies: {
-        authentication: {
-          message: (
-            <FormattedMessage id="dependency.loading.authentication.status" defaultMessage="Authentication Status" />
-          ),
-          satisfied: this.state.authStatusDetermined,
-        },
-        ...UIStore.getDependencies(),
-      },
+      dependencies: UIStore.getDependencies(),
     });
   }
 

--- a/client/src/javascript/components/AppWrapper.js
+++ b/client/src/javascript/components/AppWrapper.js
@@ -110,6 +110,8 @@ class AuthEnforcer extends React.Component {
   }
 
   handleLoginSuccess() {
+    SettingsStore.fetchClientSettings();
+    SettingsStore.fetchFloodSettings();
     FloodActions.restartActivityStream();
     this.setState({authStatusDetermined: true, isAuthenticated: true});
     browserHistory.replace('overview');

--- a/server/app.js
+++ b/server/app.js
@@ -21,6 +21,7 @@ if (process.env.NODE_ENV !== 'development') {
   app.disable('x-powered-by');
 }
 
+app.set('etag', false);
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'pug');
 


### PR DESCRIPTION
Moves the invocation of these API calls to an event handler for `AuthStore`'s `AUTH_VERIFY_SUCCESS`.

This PR also removes the weird local dependency in `AppWrapper` on the settings routes. The whole app's data fetching architecture needs a refactor but this fixes one dumb decision I made a while ago.

## Description
Attempts to fix https://github.com/jfurrow/flood/issues/713

## Related Issue
https://github.com/jfurrow/flood/issues/713