### PR TITLE
add isAdmin flag in multi-user migration script

### DIFF
--- a/server/bin/migrations/per-user-rtorrent-instances.js
+++ b/server/bin/migrations/per-user-rtorrent-instances.js
@@ -34,14 +34,13 @@ const migrate = () => {
                 host: null,
                 port: null,
                 socketPath: null,
-                isAdmin: true,
               };
             }
 
             // If none of the xmlrpc fields are on the user object, try to infer this from the legacy
             // configuration file.
             if (user.host == null && user.port == null && user.socketPath == null) {
-              userPatch = {};
+              userPatch = {isAdmin: true};
 
               if (existingConfig.socketPath && existingConfig.socketPath.trim().length > 0) {
                 userPatch.socketPath = existingConfig.socketPath;

--- a/server/bin/migrations/per-user-rtorrent-instances.js
+++ b/server/bin/migrations/per-user-rtorrent-instances.js
@@ -34,6 +34,7 @@ const migrate = () => {
                 host: null,
                 port: null,
                 socketPath: null,
+                isAdmin: true,
               };
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`isAdmin` flag is not set on user migration when upgrading to multi-rtorrent feature

## Related Issue
https://github.com/jfurrow/flood/pull/718#issuecomment-425719430

## Motivation and Context
https://github.com/jfurrow/flood/pull/718#issuecomment-425719430


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
