### PR TITLE
is admin migration

### DIFF
--- a/server/bin/migrations/fix-is-admin-flag.js
+++ b/server/bin/migrations/fix-is-admin-flag.js
@@ -19,8 +19,6 @@ const migrate = () => {
           users.map(user => {
             let userPatch = null;
 
-            // If none of the xmlrpc fields are on the user object, try to infer this from the legacy
-            // configuration file.
             if (user.isAdmin == null) {
               userPatch = {isAdmin: true};
             }

--- a/server/bin/migrations/fix-is-admin-flag.js
+++ b/server/bin/migrations/fix-is-admin-flag.js
@@ -1,0 +1,51 @@
+const chalk = require('chalk');
+const Users = require('../../models/Users');
+
+const log = data => {
+  if (process.env.DEBUG) {
+    console.log(data);
+  }
+};
+
+const migrate = () => {
+  log(chalk.green('Migrating data: resolving unset isAdmin flag'));
+
+  return new Promise((resolve, reject) => {
+    Users.listUsers((users, error) => {
+      if (error) return reject(error);
+
+      resolve(
+        Promise.all(
+          users.map(user => {
+            let userPatch = null;
+
+            // If none of the xmlrpc fields are on the user object, try to infer this from the legacy
+            // configuration file.
+            if (user.isAdmin == null) {
+              userPatch = {isAdmin: true};
+            }
+
+            if (userPatch != null) {
+              log(chalk.yellow(`Migrating user ${user.username}`));
+
+              return new Promise((resolve, reject) => {
+                Users.updateUser(user.username, userPatch, (response, error) => {
+                  if (error) {
+                    reject(error);
+                    return;
+                  }
+
+                  resolve(response);
+                });
+              });
+            }
+
+            return Promise.resolve();
+          })
+        )
+      );
+    });
+  });
+};
+
+module.exports = migrate;

--- a/server/bin/migrations/run.js
+++ b/server/bin/migrations/run.js
@@ -1,6 +1,7 @@
 const perUserRtorrentInstances = require('./per-user-rtorrent-instances');
+const fixIsAdminFlag = require('./fix-is-admin-flag');
 
-const migrations = [perUserRtorrentInstances];
+const migrations = [perUserRtorrentInstances, fixIsAdminFlag];
 
 const migrate = () => Promise.all(migrations.map(migration => migration()));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a migration for handling cases when `per-user-rtorrent-instance.js` migration was run before patch

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
see https://github.com/jfurrow/flood/pull/718#issuecomment-425719430

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We introduced `isAdmin` flag for user but forgot until yesterday to set it when running migration from previous single rtorrent instance for all users

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
locally

## Screenshots (if appropriate):
n/a
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
