### PR TITLE
Stop polling when there are no active connnections for user

### DIFF
--- a/server/services/connectionManager.js
+++ b/server/services/connectionManager.js
@@ -1,0 +1,22 @@
+const BaseService = require('./BaseService');
+
+class ConnectionManager extends BaseService {
+  constructor() {
+    super(...arguments);
+    this.connections = 0;
+  }
+
+  connect() {
+    this.connections++;
+  }
+
+  disconnect() {
+    this.connections--;
+  }
+
+  hasConnections() {
+    return this.connections > 0;
+  }
+}
+
+module.exports = ConnectionManager;

--- a/server/services/historyService.js
+++ b/server/services/historyService.js
@@ -97,8 +97,6 @@ class HistoryService extends BaseService {
       nextEraUpdateInterval: 1000 * 20, // 20 seconds
       nextEra: this.thirtyMinSnapshot,
     });
-
-    this.fetchCurrentTransferSummary();
   }
 
   checkSnapshotDiffs() {
@@ -134,14 +132,18 @@ class HistoryService extends BaseService {
   }
 
   fetchCurrentTransferSummary() {
-    if (this.pollTimeout != null) {
-      clearTimeout(this.pollTimeout);
-    }
+    this.clearFetchPoll();
 
     this.services.clientGatewayService
       .fetchTransferSummary(transferSummaryMethodCallConfig)
       .then(this.handleFetchTransferSummarySuccess.bind(this))
       .catch(this.handleFetchTransferSummaryError.bind(this));
+  }
+
+  clearFetchPoll() {
+    if (this.pollTimeout != null) {
+      clearTimeout(this.pollTimeout);
+    }
   }
 
   getTransferSummary() {

--- a/server/services/index.js
+++ b/server/services/index.js
@@ -5,6 +5,7 @@ const HistoryService = require('./historyService');
 const NotificationService = require('./notificationService');
 const TaxonomyService = require('./taxonomyService');
 const TorrentService = require('./torrentService');
+const ConnectionManager = require('./connectionManager');
 
 const clientRequestManagers = new Map();
 const clientGatewayServices = new Map();
@@ -13,6 +14,7 @@ const historyServices = new Map();
 const notificationServices = new Map();
 const taxonomyServices = new Map();
 const torrentServices = new Map();
+const connectionManagers = new Map();
 const allServiceMaps = [
   clientRequestManagers,
   clientGatewayServices,
@@ -21,6 +23,7 @@ const allServiceMaps = [
   notificationServices,
   taxonomyServices,
   torrentServices,
+  connectionManagers,
 ];
 
 const getService = ({servicesMap, service, user}) => {
@@ -61,6 +64,10 @@ const getTorrentService = user => {
   return getService({servicesMap: torrentServices, service: TorrentService, user});
 };
 
+const getConnectionManager = user => {
+  return getService({servicesMap: connectionManagers, service: ConnectionManager, user});
+};
+
 const bootstrapServicesForUser = user => {
   getClientRequestManager(user);
   getClientGatewayService(user);
@@ -69,6 +76,7 @@ const bootstrapServicesForUser = user => {
   getNotificationService(user);
   getTaxonomyService(user);
   getTorrentService(user);
+  getConnectionManager(user);
 };
 
 const destroyUserServices = user => {
@@ -110,6 +118,10 @@ const getAllServices = user => {
 
     get torrentService() {
       return getTorrentService(user);
+    },
+
+    get connectionManager() {
+      return getConnectionManager(user);
     },
   };
 };

--- a/server/services/torrentService.js
+++ b/server/services/torrentService.js
@@ -45,8 +45,6 @@ class TorrentService extends BaseService {
     clientGatewayService.on(clientGatewayServiceEvents.PROCESS_TORRENT, this.handleTorrentProcessed);
 
     clientGatewayService.on(clientGatewayServiceEvents.TORRENTS_REMOVED, this.handleTorrentsRemoved);
-
-    this.fetchTorrentList();
   }
 
   assignDeletedTorrentsToDiff(diff, nextTorrentListSummary, options = {}) {
@@ -92,14 +90,18 @@ class TorrentService extends BaseService {
   }
 
   fetchTorrentList() {
-    if (this.pollTimeout != null) {
-      clearTimeout(this.pollTimeout);
-    }
+    this.clearFetchPoll();
 
     return this.services.clientGatewayService
       .fetchTorrentList(torrentListMethodCallConfig)
       .then(this.handleFetchTorrentListSuccess)
       .catch(this.handleFetchTorrentListError);
+  }
+
+  clearFetchPoll() {
+    if (this.pollTimeout != null) {
+      clearTimeout(this.pollTimeout);
+    }
   }
 
   getTorrentETAFromDetails(torrentDetails) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Disable polling in torrent service and history service when a user is not connected. 
Added a "connection manager" to keep track of the number of connections each user has.
Currently I'm directly calling the fetch methods, but maybe it's smarter to add some more generic methods for starting and stopping polling that all the services could theoretically use. 

## Related Issue
#405
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The motivation behind this change is to reduce the idle CPU usage of flood. Currently flood will regularly poll rtorrent even if there are no active clients connected. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has only been tested locally with three users and one active rtorrent server.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This might be a breaking change if something in flood depends on the always on background polling, but I'm not sure. If so I think it would be smart to add a new config option to turn on or off idle polling. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
