### PR TITLE
Update to geoip-lite

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "flood-ui-kit": "^0.1.8",
     "flux": "^3.1.3",
     "fs-extra": "^5.0.0",
-    "geoip-country-only": "^1.1.8",
+    "geoip-lite": "^1.3.5",
     "html-webpack-plugin": "^3.1.0",
     "joi": "^13.7.0",
     "jsonwebtoken": "^8.4.0",

--- a/server/util/clientResponseUtil.js
+++ b/server/util/clientResponseUtil.js
@@ -1,4 +1,4 @@
-const geoip = require('geoip-country-only');
+const geoip = require('geoip-lite');
 const torrentFilePropsMap = require('../../shared/constants/torrentFilePropsMap');
 const torrentPeerPropsMap = require('../../shared/constants/torrentPeerPropsMap');
 const torrentTrackerPropsMap = require('../../shared/constants/torrentTrackerPropsMap');


### PR DESCRIPTION
This fixes the issue with deprecated `geoip-country-only`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Right now building fails dues to that `geoip-country-only` is deprecated. This fixes that issue.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
Fixes https://github.com/jfurrow/flood/issues/751
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See description

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I ran the docker build process and installed rTorrent alongside with it. Everything seems to works.
<!--- Include details of your testing environment, and the tests you ran to -->
I used Ubuntu 18.04.1 Server with `docker-ce` installed and ran
```
docker build -t rtorrent-flood .
docker run --name rtorrent-flood -e RTORRENT_SCGI_HOST=50000 -p 3000:3000 rtorrent-flood
```
with my branch checked out in git and rTorrent installed with [this](https://github.com/StayPirate/alpine-rtorrent) docker.
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
