### PR TITLE
Replace geoip-country-only with geoip-lite (closes #751 and #753)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1650,15 +1650,6 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
-    "binary": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
-      "requires": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
-      }
-    },
     "binary-extensions": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
@@ -2047,6 +2038,11 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -2072,11 +2068,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
-    },
-    "buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -2248,14 +2239,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
       "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
-    },
-    "chainsaw": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
-      "requires": {
-        "traverse": ">=0.3.0 <0.4"
-      }
     },
     "chalk": {
       "version": "2.4.1",
@@ -4682,6 +4665,14 @@
         }
       }
     },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
     "feedme": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/feedme/-/feedme-1.2.0.tgz",
@@ -5426,27 +5417,6 @@
         }
       }
     },
-    "fstream": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
-      "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
-      "requires": {
-        "graceful-fs": "~3.0.2",
-        "inherits": "~2.0.0",
-        "mkdirp": "0.5",
-        "rimraf": "2"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-          "requires": {
-            "natives": "^1.1.0"
-          }
-        }
-      }
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -5481,46 +5451,19 @@
         "globule": "^1.0.0"
       }
     },
-    "geoip-country-only": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/geoip-country-only/-/geoip-country-only-1.1.8.tgz",
-      "integrity": "sha1-AOrLpjf5nCk0CK2P7+KKfcfks8o=",
+    "geoip-lite": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/geoip-lite/-/geoip-lite-1.3.5.tgz",
+      "integrity": "sha512-QQUV4PC/7/eHhZU1//NZm5O6bmitACEqsoIa48Hmfh7FfUeweJJhLvM4Fw5okKlyhrBycMr2fe0v3KtlaEyHkQ==",
       "requires": {
-        "async": "~1.5.2",
-        "colors": "1.1.2",
-        "glob": "~7.0.3",
-        "iconv-lite": "~0.4.13",
-        "lazy": "~1.0.11",
-        "rimraf": "~2.5.2",
-        "unzip": "~0.1.11"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "glob": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.2",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.5.4",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        }
+        "async": "^2.1.1",
+        "colors": "^1.1.2",
+        "glob": "^7.1.1",
+        "iconv-lite": "^0.4.13",
+        "ip-address": "^5.8.9",
+        "lazy": "^1.0.11",
+        "rimraf": "^2.5.2",
+        "yauzl": "^2.9.2"
       }
     },
     "get-caller-file": {
@@ -6498,6 +6441,32 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true
+    },
+    "ip-address": {
+      "version": "5.8.9",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.8.9.tgz",
+      "integrity": "sha512-7ay355oMN34iXhET1BmCJVsHjOTSItEEIIpOs38qUC23AIhOy+xIPnkrTuEFjeLMrTJ7m8KMXWgWfy/2Vn9sDw==",
+      "requires": {
+        "jsbn": "1.1.0",
+        "lodash.find": "^4.6.0",
+        "lodash.max": "^4.0.1",
+        "lodash.merge": "^4.6.0",
+        "lodash.padstart": "^4.6.1",
+        "lodash.repeat": "^4.1.0",
+        "sprintf-js": "1.1.0"
+      },
+      "dependencies": {
+        "jsbn": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+          "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
+        },
+        "sprintf-js": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.0.tgz",
+          "integrity": "sha1-z/yvcC2vZeo5u04PorKZzsGhvkY="
+        }
+      }
     },
     "ipaddr.js": {
       "version": "1.8.0",
@@ -8319,6 +8288,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
+    "lodash.find": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
+      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -8349,10 +8323,20 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
+    "lodash.max": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
+      "integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
     },
     "lodash.mergewith": {
       "version": "4.6.1",
@@ -8363,6 +8347,16 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lodash.padstart": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
+    },
+    "lodash.repeat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.1.0.tgz",
+      "integrity": "sha1-/H3oEx2MisB+S0n3T/6CnR8r7EQ="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -8473,15 +8467,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
       "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
       "dev": true
-    },
-    "match-stream": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
-      "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
-      "requires": {
-        "buffers": "~0.1.1",
-        "readable-stream": "~1.0.0"
-      }
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
@@ -8909,11 +8894,6 @@
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
-    },
-    "natives": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.3.tgz",
-      "integrity": "sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -9477,11 +9457,6 @@
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
       "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs="
     },
-    "over": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
-      "integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg="
-    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -9706,6 +9681,11 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -11844,17 +11824,6 @@
       "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.7.tgz",
       "integrity": "sha1-wA1cUSi6xYBr7BXSt+fNq+QlMfM="
     },
-    "pullstream": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
-      "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
-      "requires": {
-        "over": ">= 0.0.5 < 1",
-        "readable-stream": "~1.0.31",
-        "setimmediate": ">= 1.0.2 < 2",
-        "slice-stream": ">= 1.0.0 < 2"
-      }
-    },
     "punycode": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
@@ -13179,14 +13148,6 @@
         }
       }
     },
-    "slice-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
-      "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
-      "requires": {
-        "readable-stream": "~1.0.31"
-      }
-    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -14181,11 +14142,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "traverse": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
-    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -14469,19 +14425,6 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         }
-      }
-    },
-    "unzip": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
-      "integrity": "sha1-iXScY7BY19kNYZ+GuYqhU107l/A=",
-      "requires": {
-        "binary": ">= 0.3.0 < 1",
-        "fstream": ">= 0.1.30 < 1",
-        "match-stream": ">= 0.0.2 < 1",
-        "pullstream": ">= 0.4.1 < 1",
-        "readable-stream": "~1.0.31",
-        "setimmediate": ">= 1.0.1 < 2"
       }
     },
     "unzip-response": {
@@ -15427,6 +15370,15 @@
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
         }
+      }
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "flood-ui-kit": "^0.1.8",
     "flux": "^3.1.3",
     "fs-extra": "^5.0.0",
-    "geoip-country-only": "^1.1.8",
+    "geoip-lite": "^1.3.5",
     "html-webpack-plugin": "^3.1.0",
     "joi": "^13.7.0",
     "jsonwebtoken": "^8.4.0",

--- a/server/util/clientResponseUtil.js
+++ b/server/util/clientResponseUtil.js
@@ -1,4 +1,4 @@
-const geoip = require('geoip-country-only');
+const geoip = require('geoip-lite');
 const torrentFilePropsMap = require('../../shared/constants/torrentFilePropsMap');
 const torrentPeerPropsMap = require('../../shared/constants/torrentPeerPropsMap');
 const torrentTrackerPropsMap = require('../../shared/constants/torrentTrackerPropsMap');


### PR DESCRIPTION
## Description

This replaces `geoip-country-only` as it is ancient (last updated 2 years ago) and gets its data from the old version of GeoLite. 

GeoLite2 has been around for a while, with GeoLite getting deprecated sometime last year. On 2nd January 2019 they removed the legacy GeoLite dataset from the website, so requests to it now 404 - as per the error we're getting in #751.

See: https://github.com/bluesmoon/node-geoip/issues/85#issuecomment-373958249

## How Has This Been Tested?

From #753:
> I ran the docker build process and installed rTorrent alongside with it. Everything seems to works.
> I used Ubuntu 18.04.1 Server with `docker-ce` installed and ran
> 
```
docker build -t rtorrent-flood .
docker run --name rtorrent-flood -e RTORRENT_SCGI_HOST=50000 -p 3000:3000 rtorrent-flood
```
> 
> with my branch checked out in git and rTorrent installed with [this](https://github.com/StayPirate/alpine-rtorrent) docker.

## Types of changes
 
* [x]  Bug fix (non-breaking change which fixes an issue)
* [ ]  New feature (non-breaking change which adds functionality) 
* [ ]  Breaking change (fix or feature that would cause existing functionality to change)
 
 
 ## Checklist:
 
* [x]  My code follows the code style of this project.
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.
* [x]  I have read the **CONTRIBUTING** document.
* [ ]  I have added tests to cover my changes.
* [x]  All new and existing tests passed.
