### PR TITLE
Added license and repository location to npm manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "flood",
   "version": "1.0.0",
   "private": false,
+  "license" : "GPL-3.0-only"
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/jfurrow/flood.git"
+  }
   "scripts": {
     "build": "node client/scripts/build.js",
     "build-assets": "UPDATED_SCRIPT=build npm run deprecated-warning && npm run build",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "flood",
   "version": "1.0.0",
   "private": false,
-  "license" : "GPL-3.0-only"
+  "license": "GPL-3.0-only",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/jfurrow/flood.git"
-  }
+    "type": "git",
+    "url": "https://github.com/jfurrow/flood.git"
+  },
   "scripts": {
     "build": "node client/scripts/build.js",
     "build-assets": "UPDATED_SCRIPT=build npm run deprecated-warning && npm run build",


### PR DESCRIPTION
## Motivation and Context
It just hides these two warnings, most likely affects nothing else.
```
npm WARN flood@1.0.0 No repository field.
npm WARN flood@1.0.0 No license field.
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly. (There's nothing to update)
- [X] I have read the **CONTRIBUTING** document. (There does not seem to be a `CONTRIBUTING` file?)
- [X] I have added tests to cover my changes. (There's nothing to test?)
- [X] All new and existing tests passed.
