### PR TITLE
Fix downloaded rounding showing 100% when not all pieces are downloaded

### DIFF
--- a/server/services/torrentService.js
+++ b/server/services/torrentService.js
@@ -5,6 +5,7 @@ const config = require('../../config');
 const formatUtil = require('../../shared/util/formatUtil');
 const methodCallUtil = require('../util/methodCallUtil');
 const serverEventTypes = require('../../shared/constants/serverEventTypes');
+const toFixedTruncate = require('../util/truncateUtil');
 const torrentListPropMap = require('../constants/torrentListPropMap');
 const torrentServiceEvents = require('../constants/torrentServiceEvents');
 const torrentStatusMap = require('../../shared/constants/torrentStatusMap');
@@ -116,9 +117,9 @@ class TorrentService extends BaseService {
     const percentComplete = (torrentDetails.bytesDone / torrentDetails.sizeBytes) * 100;
 
     if (percentComplete > 0 && percentComplete < 10) {
-      return Number(percentComplete.toFixed(2));
+      return Number(toFixedTruncate(percentComplete, 2));
     } else if (percentComplete > 10 && percentComplete < 100) {
-      return Number(percentComplete.toFixed(1));
+      return Number(toFixedTruncate(percentComplete, 1));
     }
 
     return percentComplete;

--- a/server/services/torrentService.js
+++ b/server/services/torrentService.js
@@ -5,7 +5,7 @@ const config = require('../../config');
 const formatUtil = require('../../shared/util/formatUtil');
 const methodCallUtil = require('../util/methodCallUtil');
 const serverEventTypes = require('../../shared/constants/serverEventTypes');
-const toFixedTruncate = require('../util/truncateUtil');
+const truncateTo = require('../util/numberUtils');
 const torrentListPropMap = require('../constants/torrentListPropMap');
 const torrentServiceEvents = require('../constants/torrentServiceEvents');
 const torrentStatusMap = require('../../shared/constants/torrentStatusMap');
@@ -117,9 +117,9 @@ class TorrentService extends BaseService {
     const percentComplete = (torrentDetails.bytesDone / torrentDetails.sizeBytes) * 100;
 
     if (percentComplete > 0 && percentComplete < 10) {
-      return Number(toFixedTruncate(percentComplete, 2));
+      return Number(truncateTo(percentComplete, 2));
     } else if (percentComplete > 10 && percentComplete < 100) {
-      return Number(toFixedTruncate(percentComplete, 1));
+      return Number(truncateTo(percentComplete, 1));
     }
 
     return percentComplete;

--- a/server/util/clientResponseUtil.js
+++ b/server/util/clientResponseUtil.js
@@ -1,4 +1,5 @@
 const geoip = require('geoip-lite');
+const toFixedTruncate = require('./truncateUtil');
 const torrentFilePropsMap = require('../../shared/constants/torrentFilePropsMap');
 const torrentPeerPropsMap = require('../../shared/constants/torrentPeerPropsMap');
 const torrentTrackerPropsMap = require('../../shared/constants/torrentTrackerPropsMap');
@@ -72,7 +73,7 @@ let clientResponseUtil = {
 
   processFile(file) {
     file.filename = file.pathComponents[file.pathComponents.length - 1];
-    file.percentComplete = ((file.completedChunks / file.sizeChunks) * 100).toFixed(0);
+    file.percentComplete = toFixedTruncate((file.completedChunks / file.sizeChunks) * 100);
 
     delete file.completedChunks;
     delete file.pathComponents;

--- a/server/util/clientResponseUtil.js
+++ b/server/util/clientResponseUtil.js
@@ -1,5 +1,5 @@
 const geoip = require('geoip-lite');
-const toFixedTruncate = require('./truncateUtil');
+const truncateTo = require('./numberUtils');
 const torrentFilePropsMap = require('../../shared/constants/torrentFilePropsMap');
 const torrentPeerPropsMap = require('../../shared/constants/torrentPeerPropsMap');
 const torrentTrackerPropsMap = require('../../shared/constants/torrentTrackerPropsMap');
@@ -73,7 +73,7 @@ let clientResponseUtil = {
 
   processFile(file) {
     file.filename = file.pathComponents[file.pathComponents.length - 1];
-    file.percentComplete = toFixedTruncate((file.completedChunks / file.sizeChunks) * 100);
+    file.percentComplete = truncateTo((file.completedChunks / file.sizeChunks) * 100);
 
     delete file.completedChunks;
     delete file.pathComponents;

--- a/server/util/numberUtils.js
+++ b/server/util/numberUtils.js
@@ -1,0 +1,6 @@
+const truncateTo = (num, precision = 0) => {
+  const factor = 10 ** precision;
+  return Math.floor(num * factor) / factor;
+};
+
+module.exports = truncateTo;

--- a/server/util/truncateUtil.js
+++ b/server/util/truncateUtil.js
@@ -1,0 +1,6 @@
+const truncateUtil = function(num, fixed = null) {
+  var re = new RegExp('^-?\\d+(?:\\.\\d{0,' + (fixed || -1) + '})?');
+  return num.toString().match(re)[0];
+};
+
+module.exports = truncateUtil;

--- a/server/util/truncateUtil.js
+++ b/server/util/truncateUtil.js
@@ -1,6 +1,0 @@
-const truncateUtil = function(num, fixed = null) {
-  var re = new RegExp('^-?\\d+(?:\\.\\d{0,' + (fixed || -1) + '})?');
-  return num.toString().match(re)[0];
-};
-
-module.exports = truncateUtil;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Truncates rather than rounds download percent on torrent details and file list

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#558

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Flood can show 100% downloaded when not all pieces are downloaded

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran flood in docker, created torrents with files of various sizes using `dd if=/dev/zero`

## Screenshots (if appropriate):
old details
![old details](https://i.imgur.com/UAZklcJ.jpg)
old filelist
![old filelist](https://i.imgur.com/ITmddBf.jpg)
new details
![new details](https://i.imgur.com/cUBKZZz.jpg)
new filelist
![new filelist](https://i.imgur.com/pAYHBwD.jpg)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
