### PR TITLE
Housekeeping: Extract and fix strings to be localized

### DIFF
--- a/client/src/javascript/components/general/RtorrentConnectionTypeSelection.js
+++ b/client/src/javascript/components/general/RtorrentConnectionTypeSelection.js
@@ -52,7 +52,7 @@ class RtorrentConnectionTypeSelection extends Component {
       <FormRow>
         <Textbox
           id="rtorrentSocketPath"
-          label={<FormattedMessage id="auth.rtorrentSocketPath" defaultMessage="rTorrent Socket" />}
+          label={<FormattedMessage id="auth.rtorrentSocket" defaultMessage="rTorrent Socket" />}
           placeholder={this.props.intl.formatMessage({
             id: 'auth.rtorrentSocketPath',
             defaultMessage: 'rTorrent Socket Path',

--- a/client/src/javascript/components/modals/feeds-modal/FeedsTab.js
+++ b/client/src/javascript/components/modals/feeds-modal/FeedsTab.js
@@ -113,7 +113,7 @@ class FeedsTab extends React.Component {
           <Select
             defaultID={this.state.intervals[0].value}
             label={this.props.intl.formatMessage({
-              id: 'feeds.interval',
+              id: 'feeds.select.interval',
               defaultMessage: 'Interval',
             })}
             id="interval"

--- a/client/src/javascript/components/modals/settings-modal/UITab.js
+++ b/client/src/javascript/components/modals/settings-modal/UITab.js
@@ -93,7 +93,7 @@ class UITab extends SettingsTab {
             checked={visible}
             onChange={event => this.handleDetailCheckboxValueChange(id, event.target.checked)}
             modifier="dark">
-            Enabled
+            <FormattedMessage id="settings.ui.torrent.details.enabled" defaultMessage="Enabled" />
           </Checkbox>
         </span>
       );

--- a/client/src/javascript/components/modals/torrent-details-modal/TorrentFiles.js
+++ b/client/src/javascript/components/modals/torrent-details-modal/TorrentFiles.js
@@ -259,7 +259,11 @@ class TorrentFiles extends React.Component {
       );
     } else {
       directoryHeadingIconContent = <Disk />;
-      fileDetailContent = <div className="directory-tree__node directory-tree__node--file">Loading file detail...</div>;
+      fileDetailContent = (
+        <div className="directory-tree__node directory-tree__node--file">
+          <FormattedMessage id="torrents.details.files.loading" defaultMessage="Loading file detail..." />
+        </div>
+      );
     }
 
     let directoryHeadingClasses = classnames(

--- a/client/src/javascript/components/torrent-list/ActionBar.js
+++ b/client/src/javascript/components/torrent-list/ActionBar.js
@@ -92,13 +92,40 @@ class ActionBar extends React.Component {
         </div>
         <div className="actions action-bar__item action-bar__item--torrent-operations">
           <div className="action-bar__group">
-            <Action label="Start Torrent" slug="start-torrent" icon={<StartIcon />} clickHandler={this.handleStart} />
-            <Action label="Stop Torrent" slug="stop-torrent" icon={<StopIcon />} clickHandler={this.handleStop} />
+            <Action
+              label={this.props.intl.formatMessage({
+                id: 'actionbar.button.start.torrent',
+                defaultMessage: 'Start Torrent',
+              })}
+              slug="start-torrent"
+              icon={<StartIcon />}
+              clickHandler={this.handleStart}
+            />
+            <Action
+              label={this.props.intl.formatMessage({
+                id: 'actionbar.button.stop.torrent',
+                defaultMessage: 'Stop Torrent',
+              })}
+              slug="stop-torrent"
+              icon={<StopIcon />}
+              clickHandler={this.handleStop}
+            />
           </div>
           <div className="action-bar__group action-bar__group--has-divider">
-            <Action label="Add Torrent" slug="add-torrent" icon={<Add />} clickHandler={this.handleAddTorrents} />
             <Action
-              label="Remove Torrent"
+              label={this.props.intl.formatMessage({
+                id: 'actionbar.button.add.torrent',
+                defaultMessage: 'Add Torrent',
+              })}
+              slug="add-torrent"
+              icon={<Add />}
+              clickHandler={this.handleAddTorrents}
+            />
+            <Action
+              label={this.props.intl.formatMessage({
+                id: 'actionbar.button.remove.torrent',
+                defaultMessage: 'Remove Torrent',
+              })}
               slug="remove-torrent"
               icon={<Remove />}
               clickHandler={this.handleRemoveTorrents}

--- a/client/src/javascript/i18n/en.js
+++ b/client/src/javascript/i18n/en.js
@@ -1,4 +1,9 @@
 export default {
+  'actionbar.button.start.torrent': 'Start Torrent',
+  'actionbar.button.stop.torrent': 'Stop Torrent',
+  'actionbar.button.add.torrent': 'Add Torrent',
+  'actionbar.button.remove.torrent': 'Remove Torrent',
+
   'alert.torrent.add': `Successfully added {countElement} {count, plural,
       =1 {torrent}
       other {torrents}
@@ -26,6 +31,9 @@ export default {
   'alert.settings.saved': 'Successfully saved settings.',
 
   'auth.add.user': 'Add User',
+  'auth.connectionType': 'rTorrent Connection Type',
+  'auth.connectionType.tcp': 'TCP',
+  'auth.connectionType.socket': 'Unix Socket',
   'auth.create.account': 'Create Account',
   'auth.create.an.account': 'Create an account',
   'auth.create.an.account.intro': 'Welcome to Flood!',
@@ -38,6 +46,10 @@ export default {
   'auth.username': 'Username',
   'auth.admin': 'Admin',
   'auth.message.not.admin': 'User is not Admin',
+  'auth.rtorrentHost': 'rTorrent Host',
+  'auth.rtorrentPort': 'rTorrent Port',
+  'auth.rtorrentSocket': 'rTorrent Socket',
+  'auth.rtorrentSocketPath': 'rTorrent Socket Path',
 
   'button.add': 'Add',
   'button.cancel': 'Cancel',
@@ -178,6 +190,7 @@ export default {
   'settings.ui.torrent.size': 'Torrent Size',
   'settings.ui.torrent.size.expanded': 'Expanded View',
   'settings.ui.torrent.size.condensed': 'Condensed View',
+  'settings.ui.torrent.details.enabled': 'Enabled',
   'settings.ui.torrent.details.tags.placement': 'In the expanded view, tags work best at the end of the list.',
 
   'sidebar.button.feeds': 'Feeds',
@@ -226,6 +239,7 @@ export default {
   'torrents.details.actions.stop': 'Stop',
   'torrents.details.details': 'Details',
   'torrents.details.files': 'Files',
+  'torrents.details.files.loading': 'Loading file detail...',
   'torrents.details.files.download.file': `{count, plural,
     =1 {Download File}
     other {Download Files}


### PR DESCRIPTION
Dear maintainers,

I've extracted some strings unlocalized. Please consider this request. 

Thank you.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Following strings are extracted to `i18n/en.js` or fixed their tags:
* Extracted
  - ActionBar icons
  - Settings > `rTorrent connections`
  - Settings > Columns `Enabled`
  - Torrent details > Files > `Loading...`
* Tags fixed
  - `feeds.select.interval` <- `feeds.interval`
  - `auth.rtorrentSocket` <- `auth.rtorrentSocketPath`: `rTorrent Socket`
    - There is `rTorrent Socket Path` which is also tagged as `auth.rtorrentSocketPath`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

None.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
